### PR TITLE
Ftr/model/62816/image confidence

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.AIclipse.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/indexLayout.xml
+++ b/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/model-cycle/.idea/.idea.model-cycle.dir/.idea/.gitignore
+++ b/model-cycle/.idea/.idea.model-cycle.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/.idea.model-cycle.iml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/model-cycle/.idea/.idea.model-cycle.dir/.idea/encodings.xml
+++ b/model-cycle/.idea/.idea.model-cycle.dir/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/model-cycle/.idea/.idea.model-cycle.dir/.idea/indexLayout.xml
+++ b/model-cycle/.idea/.idea.model-cycle.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/model-cycle/.idea/.idea.model-cycle.dir/.idea/vcs.xml
+++ b/model-cycle/.idea/.idea.model-cycle.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/model-cycle/Dockerfile
+++ b/model-cycle/Dockerfile
@@ -1,21 +1,18 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
 WORKDIR /src
 
 COPY ModelCycle/ModelCycle.csproj ModelCycle/
-
 RUN dotnet restore ModelCycle/ModelCycle.csproj
 
 COPY ModelCycle/ ModelCycle/
-
 RUN dotnet publish ModelCycle/ModelCycle.csproj -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS final
 WORKDIR /app
 
 COPY --from=build /app/publish .
 
 ENV ASPNETCORE_URLS=http://+:3000
-
 EXPOSE 3000
 
 ENTRYPOINT ["dotnet", "ModelCycle.dll"]

--- a/model-cycle/Dockerfile
+++ b/model-cycle/Dockerfile
@@ -1,11 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-COPY ModelCycle.csproj .
-RUN dotnet restore
+COPY ModelCycle/ModelCycle.csproj ModelCycle/
 
-COPY . .
-RUN dotnet publish -c Release -o /app/publish
+RUN dotnet restore ModelCycle/ModelCycle.csproj
+
+COPY ModelCycle/ ModelCycle/
+
+RUN dotnet publish ModelCycle/ModelCycle.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app

--- a/model-cycle/Folder.DotSettings.user
+++ b/model-cycle/Folder.DotSettings.user
@@ -1,0 +1,15 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003ATestInvoker_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003F_002E_002E_003FAppData_003FRoaming_003FJetBrains_003FRider2025_002E2_003Fresharper_002Dhost_003FSourcesCache_003Fc3ec25c53b94f51fa21da479c513e551efee2b5ae49a79934686d2bb714d46_003FTestInvoker_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=637a8202_002D89c2_002D45b2_002D8e74_002Dfaa5e011b13d/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="HighCertainty_AboveThreshold_IsReadyForTraining #3" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::11ECFD39-D994-1242-B871-A28B2AA04A73::net8.0::Tests.ImageConfidence.ConfidenceServiceTests.HighCertainty_AboveThreshold_IsReadyForTraining&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=c6e5c091_002D79e9_002D401b_002D8ed4_002D688457672ccd/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="HighCertainty_AboveThreshold_IsReadyForTraining #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Project Location="C:\Users\seanm\Desktop\AIclipse\model-cycle\Tests" Presentation="&amp;lt;Tests&amp;gt;" /&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=d31bce19_002Dee2f_002D4709_002Da9ba_002De094ca86ac08/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="HighCertainty_AboveThreshold_IsReadyForTraining" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::11ECFD39-D994-1242-B871-A28B2AA04A73::net8.0::Tests.ImageConfidence.ConfidenceServiceTests.HighCertainty_AboveThreshold_IsReadyForTraining&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/model-cycle/ModelCycle.csproj
+++ b/model-cycle/ModelCycle.csproj
@@ -1,9 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
-</Project>

--- a/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/.gitignore
+++ b/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/.idea.model-cycle.iml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/encodings.xml
+++ b/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/indexLayout.xml
+++ b/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/vcs.xml
+++ b/model-cycle/ModelCycle/.idea/.idea.model-cycle.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/model-cycle/ModelCycle/Controllers/ImageConfidenceController.cs
+++ b/model-cycle/ModelCycle/Controllers/ImageConfidenceController.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ModelCycle.Domain;
+using ModelCycle.Services.ImageConfidence;
+
+namespace ModelCycle.Controllers;
+
+public class ImageConfidenceController:ControllerBase
+{
+    private readonly IConfidenceService _confidence;
+
+    public ImageConfidenceController(IConfidenceService confidence)
+    {
+        _confidence = confidence;
+    }
+
+    [HttpPost("/confidence")]
+    public IActionResult Evaluate(ImageVote vote)
+    {
+        var result = _confidence.Evaluate(vote);
+        return Ok(result);
+    }
+}

--- a/model-cycle/ModelCycle/Domain/ConfidenceResult.cs
+++ b/model-cycle/ModelCycle/Domain/ConfidenceResult.cs
@@ -1,0 +1,11 @@
+﻿namespace ModelCycle.Domain;
+
+public class ConfidenceResult
+{
+    public bool IsReadyForTraining { get; set; }
+    public double PosteriorMean { get; set; }
+    public double Alpha { get; set; }
+    public double Beta { get; set; }
+    public double Probability { get; set; }
+    public required string TrainingLabel { get; set; }
+}

--- a/model-cycle/ModelCycle/Domain/ImageVote.cs
+++ b/model-cycle/ModelCycle/Domain/ImageVote.cs
@@ -4,4 +4,6 @@ public class ImageVote
 {
     public int UserAiVotes { get; set; }
     public int UserNotAiVotes { get; set; }
+    
+    public double ModelConfidence { get; set; }
 }

--- a/model-cycle/ModelCycle/Domain/ImageVote.cs
+++ b/model-cycle/ModelCycle/Domain/ImageVote.cs
@@ -2,6 +2,7 @@
 
 public class ImageVote
 {
+    public Guid ImageId { get; set; }
     public int UserAiVotes { get; set; }
     public int UserNotAiVotes { get; set; }
     

--- a/model-cycle/ModelCycle/Domain/ImageVote.cs
+++ b/model-cycle/ModelCycle/Domain/ImageVote.cs
@@ -2,7 +2,7 @@
 
 public class ImageVote
 {
-    public Guid ImageId { get; set; }
+    public Guid PostId { get; set; }
     public int UserAiVotes { get; set; }
     public int UserNotAiVotes { get; set; }
     

--- a/model-cycle/ModelCycle/Domain/ImageVote.cs
+++ b/model-cycle/ModelCycle/Domain/ImageVote.cs
@@ -1,0 +1,7 @@
+﻿namespace ModelCycle.Domain;
+
+public class ImageVote
+{
+    public int UserAiVotes { get; set; }
+    public int UserNotAiVotes { get; set; }
+}

--- a/model-cycle/ModelCycle/ModelCycle.csproj
+++ b/model-cycle/ModelCycle/ModelCycle.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/model-cycle/ModelCycle/ModelCycle.csproj
+++ b/model-cycle/ModelCycle/ModelCycle.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Python\" />
+    <Folder Include="Services\Data\" />
+    <Folder Include="Services\Training\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_ContentIncludedByDefault Remove="Tests\obj\project.assets.json" />
+    <_ContentIncludedByDefault Remove="Tests\obj\Tests.csproj.nuget.dgspec.json" />
+  </ItemGroup>
+
+</Project>

--- a/model-cycle/ModelCycle/Program.cs
+++ b/model-cycle/ModelCycle/Program.cs
@@ -3,8 +3,12 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ModelCycle.Services.ImageConfidence;
+
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSingleton<IBetaDistribution, BetaDistribution>();
+builder.Services.AddSingleton<IConfidenceService, ConfidenceService>();
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();

--- a/model-cycle/ModelCycle/Program.cs
+++ b/model-cycle/ModelCycle/Program.cs
@@ -10,6 +10,11 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton<IBetaDistribution, BetaDistribution>();
 builder.Services.AddSingleton<IConfidenceService, ConfidenceService>();
 
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 
@@ -17,6 +22,11 @@ builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
 builder.Logging.AddFilter("System.Net.Http", LogLevel.Warning);
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapControllers();
 
 app.MapGet("/healthz", () => Results.Json(new { status = "ok" }));
 

--- a/model-cycle/ModelCycle/Services/ImageConfidence/BetaDistribution.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/BetaDistribution.cs
@@ -1,0 +1,12 @@
+﻿using MathNet.Numerics.Distributions;
+
+namespace ModelCycle.Services.ImageConfidence;
+
+public class BetaDistribution: IBetaDistribution
+{
+    public double Cdf(double x, double alpha, double beta)
+    {
+        var betaDist = new Beta(alpha, beta);
+        return betaDist.CumulativeDistribution(x);
+    }
+}

--- a/model-cycle/ModelCycle/Services/ImageConfidence/BetaDistribution.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/BetaDistribution.cs
@@ -2,7 +2,7 @@
 
 namespace ModelCycle.Services.ImageConfidence;
 
-public class BetaDistribution: IBetaDistribution
+public class BetaDistribution : IBetaDistribution
 {
     public double Cdf(double x, double alpha, double beta)
     {

--- a/model-cycle/ModelCycle/Services/ImageConfidence/ConfidenceService.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/ConfidenceService.cs
@@ -10,45 +10,42 @@ public class ConfidenceService: IConfidenceService
     {
         _beta = beta;
     }
-
+    
     public ConfidenceResult Evaluate(ImageVote vote)
     {
-        // will get initial average user's accuracy and use weighted bayesian instead
-        // will later change this so that we measure users accuracy and weigh each votes by this measure.
-        double userAccuracyAi   = 0.6; 
+        // User averages found in research - (will later be dynamic per user)
+        double userAccuracyAi  = 0.8; 
         double userAccuracyReal = 0.8; 
         
+        // Model accuracy - will get from model versioning history later
         double modelAccuracyAi = 0.8;
-        double modelAccuracyReal = 0.8; 
+        double modelAccuracyReal = 0.8;
         
-        // Calculate alpha,beta and posterior mean
-        double userAi    =  userAccuracyAi   * vote.UserAiVotes;
-        double userAiNot       = (1 - userAccuracyReal) * vote.UserNotAiVotes;
-        double userReal =  userAccuracyReal * vote.UserNotAiVotes;
-        double userRealNot     = (1 - userAccuracyAi)   * vote.UserAiVotes;
-        
-        double modelAi  =  modelAccuracyAi ;
-        double modelAiNot      = (1 - modelAccuracyReal);
-        double modelReal=  modelAccuracyReal;
-        double modelRealNot   = (1 - modelAccuracyAi);
+        double userAi = userAccuracyAi * vote.UserAiVotes;
+        double userAiNot = (1 - userAccuracyReal)  * vote.UserNotAiVotes;
+        double userReal = userAccuracyReal * vote.UserNotAiVotes;
+        double userRealNot = (1 - userAccuracyAi)  * vote.UserAiVotes;
+
+        double modelAi = vote.ModelConfidence * modelAccuracyAi;
+        double modelAiNot = (1 - vote.ModelConfidence) * (1 - modelAccuracyReal);
+
+        double modelReal = (1 - vote.ModelConfidence) * modelAccuracyReal;
+        double modelRealNot = vote.ModelConfidence * (1 - modelAccuracyAi);
         
         double alpha = 1 + userAi + userAiNot + modelAi + modelAiNot;
-
         double beta = 1 + userReal + userRealNot + modelReal + modelRealNot;
 
         double posteriorMean = alpha / (alpha + beta);
-
-        // Find label
+        
         string trainingLabel = posteriorMean >= 0.5 ? "ai" : "real";
 
-        // find probability of decided label
-        double pReal = _beta.Cdf(0.5, alpha, beta);  
-        double pAi   = 1.0 - pReal;                     
-        double probability = trainingLabel == "ai" ? pAi : pReal;
+        //Get probability of chosen label and check against threshold
+        double pReal = _beta.Cdf(0.5, alpha, beta);
+        double pAi   = 1.0 - pReal;
 
-        //passes threshold of agreement? Will change based on results from research (Ongoing)
-        double agreementThreshold = 0.9;
-        bool isReady = probability >= agreementThreshold;
+        double probability = trainingLabel == "ai" ? pAi : pReal;
+        Console.WriteLine("Probability: " + probability);
+        bool isReady = probability >= 0.8;
 
         return new ConfidenceResult
         {
@@ -57,7 +54,7 @@ public class ConfidenceService: IConfidenceService
             Alpha = alpha,
             Beta = beta,
             Probability = probability,
-            TrainingLabel = posteriorMean >= 0.5 ? "ai" : "real"
+            TrainingLabel = trainingLabel
         };
     }
 }

--- a/model-cycle/ModelCycle/Services/ImageConfidence/ConfidenceService.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/ConfidenceService.cs
@@ -1,0 +1,63 @@
+﻿using ModelCycle.Domain;
+
+namespace ModelCycle.Services.ImageConfidence;
+
+public class ConfidenceService: IConfidenceService
+{
+    private readonly IBetaDistribution _beta;
+
+    public ConfidenceService(IBetaDistribution beta)
+    {
+        _beta = beta;
+    }
+
+    public ConfidenceResult Evaluate(ImageVote vote)
+    {
+        // will get initial average user's accuracy and use weighted bayesian instead
+        // will later change this so that we measure users accuracy and weigh each votes by this measure.
+        double userAccuracyAi   = 0.6; 
+        double userAccuracyReal = 0.8; 
+        
+        double modelAccuracyAi = 0.8;
+        double modelAccuracyReal = 0.8; 
+        
+        // Calculate alpha,beta and posterior mean
+        double userAi    =  userAccuracyAi   * vote.UserAiVotes;
+        double userAiNot       = (1 - userAccuracyReal) * vote.UserNotAiVotes;
+        double userReal =  userAccuracyReal * vote.UserNotAiVotes;
+        double userRealNot     = (1 - userAccuracyAi)   * vote.UserAiVotes;
+        
+        double modelAi  =  modelAccuracyAi ;
+        double modelAiNot      = (1 - modelAccuracyReal);
+        double modelReal=  modelAccuracyReal;
+        double modelRealNot   = (1 - modelAccuracyAi);
+        
+        double alpha = 1 + userAi + userAiNot + modelAi + modelAiNot;
+
+        double beta = 1 + userReal + userRealNot + modelReal + modelRealNot;
+
+        double posteriorMean = alpha / (alpha + beta);
+
+        // Find label
+        string trainingLabel = posteriorMean >= 0.5 ? "ai" : "real";
+
+        // find probability of decided label
+        double pReal = _beta.Cdf(0.5, alpha, beta);  
+        double pAi   = 1.0 - pReal;                     
+        double probability = trainingLabel == "ai" ? pAi : pReal;
+
+        //passes threshold of agreement? Will change based on results from research (Ongoing)
+        double agreementThreshold = 0.9;
+        bool isReady = probability >= agreementThreshold;
+
+        return new ConfidenceResult
+        {
+            IsReadyForTraining = isReady,
+            PosteriorMean = posteriorMean,
+            Alpha = alpha,
+            Beta = beta,
+            Probability = probability,
+            TrainingLabel = posteriorMean >= 0.5 ? "ai" : "real"
+        };
+    }
+}

--- a/model-cycle/ModelCycle/Services/ImageConfidence/IBetaDistribution.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/IBetaDistribution.cs
@@ -1,0 +1,6 @@
+﻿namespace ModelCycle.Services.ImageConfidence;
+
+public interface  IBetaDistribution
+{
+    double Cdf(double x, double alpha, double beta);
+}

--- a/model-cycle/ModelCycle/Services/ImageConfidence/IConfidenceService.cs
+++ b/model-cycle/ModelCycle/Services/ImageConfidence/IConfidenceService.cs
@@ -1,0 +1,8 @@
+﻿using ModelCycle.Domain;
+
+namespace ModelCycle.Services.ImageConfidence;
+
+public interface IConfidenceService
+{
+    ConfidenceResult Evaluate(ImageVote vote);
+}

--- a/model-cycle/ModelCycleSolution.sln
+++ b/model-cycle/ModelCycleSolution.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModelCycle", "ModelCycle\ModelCycle.csproj", "{1F3E42E4-CAA5-47D6-82FE-3F6DAA3708EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{0A5E6C0E-4808-4917-A968-5627AA82A304}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1F3E42E4-CAA5-47D6-82FE-3F6DAA3708EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F3E42E4-CAA5-47D6-82FE-3F6DAA3708EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F3E42E4-CAA5-47D6-82FE-3F6DAA3708EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F3E42E4-CAA5-47D6-82FE-3F6DAA3708EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A5E6C0E-4808-4917-A968-5627AA82A304}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A5E6C0E-4808-4917-A968-5627AA82A304}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A5E6C0E-4808-4917-A968-5627AA82A304}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A5E6C0E-4808-4917-A968-5627AA82A304}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/model-cycle/Tests/ImageConfidence/BetaDistributionTests.cs
+++ b/model-cycle/Tests/ImageConfidence/BetaDistributionTests.cs
@@ -1,0 +1,25 @@
+﻿using ModelCycle.Services.ImageConfidence;
+using Xunit;
+
+namespace Tests.ImageConfidence;
+
+public class BetaDistributionTests
+{
+    [Fact]
+    public void Cdf_ReturnsValueBetweenZeroAndOne()
+    {
+        var beta = new BetaDistribution();
+        var result = beta.Cdf(0.5, 2, 3);
+
+        Assert.InRange(result, 0, 1);
+    }
+
+    [Fact]
+    public void Cdf_UniformDistribution_AtHalf_ReturnsHalf()
+    {
+        var beta = new BetaDistribution();
+        var result = beta.Cdf(0.5, 1, 1);
+
+        Assert.Equal(0.5, result, precision: 3);
+    }
+}

--- a/model-cycle/Tests/ImageConfidence/ConfidenceServiceTests.cs
+++ b/model-cycle/Tests/ImageConfidence/ConfidenceServiceTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using ModelCycle.Domain;
+using ModelCycle.Services.ImageConfidence;
+using Xunit;
+
+namespace Tests.ImageConfidence;
+
+ public class ConfidenceServiceTests
+    {
+        private readonly ConfidenceService _service;
+
+        public ConfidenceServiceTests()
+        {
+            _service = new ConfidenceService(new BetaDistribution());
+        }
+        
+        private (double alpha, double beta) ComputeExpectedAlphaBeta(int userAi, int userNot, double modelConf)
+        {
+            double userAccuracyAi = 0.8;
+            double userAccuracyReal = 0.8;
+
+            double modelAccuracyAi = 0.8;
+            double modelAccuracyReal = 0.8;
+
+            double userAiVal   = userAccuracyAi          * userAi;
+            double userAiNotVal = (1 - userAccuracyReal)  * userNot;
+            double userRealVal  = userAccuracyReal        * userNot;
+            double userRealNotVal= (1 - userAccuracyAi)    * userAi;
+
+            double modelAiVal = modelConf * modelAccuracyAi;
+            double modelAiNotVal = (1 - modelConf) * (1 - modelAccuracyReal);
+
+            double modelRealVal  = (1 - modelConf) * modelAccuracyReal;
+            double modelRealNotVal = modelConf * (1 - modelAccuracyAi);
+
+            double alpha = 1 + userAiVal + userAiNotVal + modelAiVal + modelAiNotVal;
+            double beta = 1 + userRealVal + userRealNotVal + modelRealVal + modelRealNotVal;
+
+            return (alpha, beta);
+        }
+        
+        [Fact]
+        public void AlphaBeta_CorrectlyComputed_WithWeightedVotes()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 2,
+                UserNotAiVotes = 3,
+                ModelConfidence = 0.7
+            };
+
+            var expected = ComputeExpectedAlphaBeta(2, 3, 0.7);
+            var result = _service.Evaluate(vote);
+
+            Assert.Equal(expected.alpha, result.Alpha, 5);
+            Assert.Equal(expected.beta, result.Beta, 5);
+        }
+        
+        [Fact]
+        public void StrongRealVotes_ProduceRealLabel()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 0,
+                UserNotAiVotes = 10,
+                ModelConfidence = 0.2
+            };
+
+            var result = _service.Evaluate(vote);
+
+            Assert.Equal("real", result.TrainingLabel);
+        }
+        
+        [Fact]
+        public void StrongAiVotes_ProduceAiLabel()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 10,
+                UserNotAiVotes = 0,
+                ModelConfidence = 0.8
+            };
+
+            var result = _service.Evaluate(vote);
+
+            Assert.Equal("ai", result.TrainingLabel);
+        }
+        
+        [Fact]
+        public void PosteriorMean_BetweenZeroAndOne()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 3,
+                UserNotAiVotes = 3,
+                ModelConfidence = 0.5
+            };
+
+            var result = _service.Evaluate(vote);
+
+            Assert.InRange(result.PosteriorMean, 0.0, 1.0);
+        }
+        
+        [Fact]
+        public void Probability_Computed_ForBothLabels()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 4,
+                UserNotAiVotes = 4,
+                ModelConfidence = 0.5
+            };
+
+            var result = _service.Evaluate(vote);
+
+            Assert.True(result.Probability > 0);
+            Assert.True(result.Probability < 1);
+        }
+        
+        [Fact]
+        public void HighCertainty_AboveThreshold_IsReadyForTraining()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 10,
+                UserNotAiVotes = 1,
+                ModelConfidence = 0.9
+            };
+            var result = _service.Evaluate(vote);
+
+            Assert.True(result.Probability >= 0.8);
+            Assert.True(result.IsReadyForTraining);
+        }
+        
+        [Fact]
+        public void LowCertainty_BelowThreshold_NotReadyForTraining()
+        {
+            var vote = new ImageVote
+            {
+                UserAiVotes = 1,
+                UserNotAiVotes = 1,
+                ModelConfidence = 0.5
+            };
+
+            var result = _service.Evaluate(vote);
+
+            Assert.True(result.Probability < 0.9);
+            Assert.False(result.IsReadyForTraining);
+        }
+    }

--- a/model-cycle/Tests/Tests.csproj
+++ b/model-cycle/Tests/Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ModelCycle\ModelCycle.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/model-demo/README.md
+++ b/model-demo/README.md
@@ -1,0 +1,64 @@
+# Model Cycle Module
+
+This module provides functionality for deciding on whether model training should commence, and trains models on new training data.
+
+In the future this module will include:
+
+- Data ingestion logic
+- Training cycle management
+- Model versioning
+- Integration with other modules
+
+### Services
+
+- ImageConfidence
+- ... MORE SERVICES TO BE ADDED
+
+### Image Confidence
+
+Checks image properties (user votes, model confidence) and transforms into posterior mean. Transforms this mean into a beta distribution and checks it against set threshold to see if image and label is ready to be added to training set.
+
+## Inputs
+
+- User vote counts
+- Model confidence score
+- Estimated accuracies for users and model (Will be per user accuracy in the future)
+
+---
+
+## Outputs
+
+A `(alpha, beta, posterior_mean, verdict)` structure:
+
+- `alpha`: strength of belief for “AI”
+- `beta`: strength of belief for “Real”
+- `posterior_mean`: final confidence score between 0 and 1
+- `verdict`: `"ai"` or `"real"`
+
+---
+
+## Module Structure
+
+```text
+model-cycle/
+ ├─ ModelCycle/
+ │   ├─ Controllers/
+ │   ├─ Domain/
+ │   │   ├─ ImageVote.cs
+ │   │   └─ ConfidenceResult.cs
+ │   ├─ Python/
+ │   │   (future: training script)
+ │   ├─ Services/
+ │   │   └─ ImageConfidence/
+ │   │       ├─ ConfidenceService.cs
+ │   │       ├─ IBetaDistribution.cs
+ │   │       └─ BetaDistribution.cs
+ │   ├─ Tests/
+ │   │   └─ ImageConfidence/
+ │   │       └─ ConfidenceServiceTests.cs
+ │   ├─ ModelCycle.csproj
+ │   └─ Program.cs
+ ├─ Dockerfile
+ └─ .dockerignore
+
+```


### PR DESCRIPTION
Added image confidence functionality and route. 
Will likely update in the future to include an accuracy of each user for their vote. Or possibly attach user id to each vote to allow for checking of their accuracy internally. 

To test the route run the model cycle project - Rider or VisualStudio. (Whatever you choose).
Visit http://localhost:5000/swagger/ or whatever port it runs on. 
Test the /confidence route. (generate a guid online for post id - Roman <3 ) 

<img width="842" height="635" alt="swaggerTest" src="https://github.com/user-attachments/assets/a6ab58e3-82ce-4b20-8d4b-21f6047349ab" />



Tests running 👍 
<img width="673" height="283" alt="modelCycleUnitTestsPass" src="https://github.com/user-attachments/assets/46ce1a4b-f599-4700-90e4-c4a0d72618a5" />

