### PR TITLE
Add infrastructure for community next.js service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,4 +239,3 @@ x86/
 # NuGet
 packages/
 *.nupkg
-project.lock.json

--- a/community/.dockerignore
+++ b/community/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+dist
+build
+coverage
+npm-debug.log
+.DS_Store

--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npx", "next", "start", "-H", "0.0.0.0", "-p", "3000"]

--- a/community/app/healthz/route.js
+++ b/community/app/healthz/route.js
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response("OK", { status: 200 });
+}

--- a/community/app/layout.jsx
+++ b/community/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/community/app/page.jsx
+++ b/community/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello world</h1>;
+}

--- a/community/next.config.js
+++ b/community/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  basePath: "/community",
+};

--- a/community/package.json
+++ b/community/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "community",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "start": "next start -H 0.0.0.0 -p 3000"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/infra/k8s-dev/ingress-srv.yaml
+++ b/infra/k8s-dev/ingress-srv.yaml
@@ -18,6 +18,13 @@ spec:
                 name: gateway-srv
                 port:
                   number: 8080
+          - path: /community
+            pathType: Prefix
+            backend:
+              service:
+                name: community-srv
+                port:
+                  number: 3000
           - path: /
             pathType: Prefix
             backend:

--- a/infra/k8s/community-depl.yaml
+++ b/infra/k8s/community-depl.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: community-depl
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: community } }
+  template:
+    metadata: { labels: { app: community } }
+    spec:
+      containers:
+        - name: community
+          image: aiclipse/community
+          env:
+            - name: MONGO_URI
+              valueFrom: { secretKeyRef: { name: mongo-sec, key: MONGO_URI } }
+            - name: MONGO_DB
+              valueFrom: { secretKeyRef: { name: mongo-sec, key: MONGO_DB } }
+          ports: [{ name: http, containerPort: 3000 }]
+
+          readinessProbe:
+            httpGet: { path: /community/healthz, port: 3000, scheme: HTTP }
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+
+          livenessProbe:
+            httpGet: { path: /community/healthz, port: 3000, scheme: HTTP }
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 1
+            failureThreshold: 3
+
+          startupProbe:
+            httpGet: { path: /community/healthz, port: 3000, scheme: HTTP }
+            periodSeconds: 1
+            failureThreshold: 60
+
+          resources:
+            requests: { cpu: "50m", memory: "64Mi" }
+            limits: { cpu: "250m", memory: "256Mi" }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: community-srv
+spec:
+  type: ClusterIP
+  selector: { app: community }
+  ports: [{ name: http, port: 3000, targetPort: 3000 }]

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - k8s/billing-depl.yaml
   #- k8s/observer-depl.yaml
   - k8s/client-depl.yaml
+  - k8s/community-depl.yaml
   - k8s-dev/ingress-srv.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -73,6 +73,14 @@ build:
     #     manual:
     #       - src: "**/*.py"
     #         dest: .
+    - image: aiclipse/community
+      context: community
+      docker: { dockerfile: Dockerfile }
+      sync:
+        manual:
+          - src: "**/*.{js,jsx,ts,tsx,json,css,scss,html}"
+            dest: .
+
 manifests:
   kustomize:
     paths:


### PR DESCRIPTION
1. run `skaffold dev`
2. open in browser `aiclipse.local/community`

You must see hello world
<img width="558" height="203" alt="image" src="https://github.com/user-attachments/assets/197d8be1-59bb-4abf-9fbe-d28ca2f054d8" />



default path for community service is `/community `NOT `/`
next.config.js:
```
/** @type {import('next').NextConfig} */
module.exports = {
  basePath: "/community",
};
```
It's very important to understand. If final route in browser is `aiclipse.local/communityposts` it will **NOT** work. It will not be redirected to community service. The valid approach will be `aiclipse.local/community/posts` or `aiclipse.local/community/communityposts`