### PR TITLE
Ftr/database/62852/setting up minio

### DIFF
--- a/MongoDB/controllers/auth.users.controller.js
+++ b/MongoDB/controllers/auth.users.controller.js
@@ -73,6 +73,12 @@ async function signup(req, res) {
       email: user.email,
       is_admin: false,
       created_at: user.created_at,
+      age: user.age,
+      plan: user.plan,
+      total_guesses: user.total_guesses,
+      total_correct: user.total_correct,
+      acc_guessing_ai: user.acc_guessing_ai,
+      acc_guessing_real: user.acc_guessing_real,
     });
   } catch (err) {
     console.error('signup error', err);
@@ -122,6 +128,13 @@ async function login(req, res) {
         user_name: user.user_name,
         email: user.email,
         is_admin: user.is_admin,
+        created_at: user.created_at,
+        age: user.age,
+        plan: user.plan,
+        total_guesses: user.total_guesses,
+        total_correct: user.total_correct,
+        acc_guessing_ai: user.acc_guessing_ai,
+        acc_guessing_real: user.acc_guessing_real,
       },
     });
   } catch (err) {

--- a/MongoDB/mongo-models/auth.users.model.js
+++ b/MongoDB/mongo-models/auth.users.model.js
@@ -51,6 +51,16 @@ const userSchema = new mongoose.Schema(
       min: 0,
       default: 0,
     },
+    acc_guessing_ai:{
+      type: Number,
+      min: 0,
+      default: 0,
+    },
+    acc_guessing_real:{
+      type: Number,
+      min: 0,
+      default: 0,
+    },
 
     // current subscription plan; 0 = free. Real billing logic will come later.
     plan: {

--- a/auth/main-auth.py
+++ b/auth/main-auth.py
@@ -92,6 +92,9 @@ class UserPublic(BaseModel):
     age: Optional[int] = None
     total_guesses: Optional[int] = 0
     total_correct: Optional[int] = 0
+    acc_guessing_ai: Optional[int] = 0
+    acc_guessing_real: Optional[int] = 0
+    
 
 
 class SignupRequest(BaseModel):
@@ -179,6 +182,8 @@ def build_user_public(doc: dict) -> UserPublic:
         age=doc.get("age"),
         total_guesses=doc.get("total_guesses", 0),
         total_correct=doc.get("total_correct", 0),
+        acc_guessing_ai=doc.get("acc_guessing_ai", 0),
+        acc_guessing_real=doc.get("acc_guessing_real", 0),
     )
 
 
@@ -288,6 +293,8 @@ async def signup(payload: SignupRequest):
         "age": None,
         "total_guesses": 0,
         "total_correct": 0,
+        "acc_guessing_ai": 0,
+        "acc_guessing_real": 0,
     }
 
     await users_coll.insert_one(user_doc)

--- a/client/static/imageProcessing.js
+++ b/client/static/imageProcessing.js
@@ -1,6 +1,3 @@
-// minimal app.js for imgProcessing.html
-
-// --- helpers ---
 function setStatus(el, type, text) {
   if (!el) return;
   el.innerHTML = "";
@@ -53,6 +50,15 @@ window.addEventListener("DOMContentLoaded", () => {
   const detectStatus = document.getElementById("detect-status");
   const detectResult = document.getElementById("detect-result");
   const debugOutput = document.getElementById("debug-output");
+  const previewImg = document.getElementById("preview-image");
+  let lastPreviewUrl = null;
+
+  // SAVE UI
+  const btnSave = document.getElementById("btn-save");
+  const savePublic = document.getElementById("save-public");
+  const saveState = document.getElementById("save-state");
+  const saveStatus = document.getElementById("save-status");
+  const saveResult = document.getElementById("save-result");
 
   // elements inside detect card
   const detectCard = document.getElementById("detect-card");
@@ -61,9 +67,51 @@ window.addEventListener("DOMContentLoaded", () => {
   const realFill = document.querySelector(".real-fill");
   const aiFill = document.querySelector(".ai-fill");
 
+  // PUBLIC IMAGES UI
+  const publicImagesEl = document.getElementById("public-images");
+
   // state
   window.lastFile = null;
   let lastDetectionToken = null;
+
+  // fetching the images (public feed)
+  async function loadPublicImages() {
+    if (!publicImagesEl) return;
+
+    try {
+      const res = await fetch("/images?is_public=true");
+      let data = null;
+      try { data = await res.json(); } catch { data = { detail: "Non-JSON response" }; }
+
+      if (!res.ok || !data.items) {
+        publicImagesEl.textContent = "Failed to load public images.";
+        return;
+      }
+
+      if (data.items.length === 0) {
+        publicImagesEl.textContent = "No public images yet.";
+        return;
+      }
+
+      publicImagesEl.innerHTML = "";
+
+      for (const img of data.items) {
+        const imageUrl = img.url;
+
+        if (!imageUrl) continue;
+
+        const el = document.createElement("img");
+        el.src = imageUrl;
+        el.alt = img.label || "Public image";
+        el.title = `${img.label || "Image"} (${((img.confidence ?? 0) * 100).toFixed(1)}%)`;
+
+        publicImagesEl.appendChild(el);
+      }
+    } catch (err) {
+      console.error(err);
+      publicImagesEl.textContent = "Error loading public images.";
+    }
+  }
 
   // file chosen -> enable check button
   if (fileInput) {
@@ -71,6 +119,29 @@ window.addEventListener("DOMContentLoaded", () => {
       const file = fileInput.files[0];
       window.lastFile = file || null;
       lastDetectionToken = null;
+
+      if (previewImg) {
+        // cleanup old blob url
+        if (lastPreviewUrl) {
+          URL.revokeObjectURL(lastPreviewUrl);
+          lastPreviewUrl = null;
+        }
+
+        if (file) {
+          lastPreviewUrl = URL.createObjectURL(file);
+          previewImg.src = lastPreviewUrl;
+          previewImg.hidden = false;
+        } else {
+          previewImg.src = "";
+          previewImg.hidden = true;
+        }
+      }
+
+      // reset SAVE UI
+      if (btnSave) btnSave.disabled = true;
+      if (saveState) saveState.textContent = "Run detection first to enable saving.";
+      if (saveResult) saveResult.textContent = "";
+      if (saveStatus) setStatus(saveStatus, "info", "");
 
       if (file) {
         if (btnCheck) btnCheck.disabled = false;
@@ -94,6 +165,13 @@ window.addEventListener("DOMContentLoaded", () => {
 
       btnCheck.disabled = true;
       lastDetectionToken = null;
+
+      // disable SAVE until token arrives
+      if (btnSave) btnSave.disabled = true;
+      if (saveState) saveState.textContent = "Run detection first to enable saving.";
+      if (saveResult) saveResult.textContent = "";
+      if (saveStatus) setStatus(saveStatus, "info", "");
+
       setStatus(detectStatus, "info", "Analyzing image...");
 
       const formData = new FormData();
@@ -107,6 +185,15 @@ window.addEventListener("DOMContentLoaded", () => {
 
         if (res.ok) {
           lastDetectionToken = data.detection_token || null;
+
+          // enable SAVE if we have a token
+          if (btnSave) btnSave.disabled = !lastDetectionToken;
+          if (saveState) {
+            saveState.textContent = lastDetectionToken
+              ? "Detection token ready. You can now save this image."
+              : "No detection token returned; cannot save.";
+          }
+
           // keep raw JSON for debugging (hidden by default)
           if (detectResult) detectResult.textContent = JSON.stringify(data, null, 2);
 
@@ -116,14 +203,64 @@ window.addEventListener("DOMContentLoaded", () => {
           setStatus(detectStatus, "success", "Detection completed.");
         } else {
           lastDetectionToken = null;
+          if (btnSave) btnSave.disabled = true;
+          if (saveState) saveState.textContent = "Run detection first to enable saving.";
           if (detectResult) detectResult.textContent = JSON.stringify(data, null, 2);
           setStatus(detectStatus, "error", data.detail || `Detection failed (${res.status})`);
         }
       } catch (err) {
         console.error(err);
+        if (btnSave) btnSave.disabled = true;
+        if (saveState) saveState.textContent = "Run detection first to enable saving.";
         setStatus(detectStatus, "error", "Network error during detection.");
       } finally {
         btnCheck.disabled = false;
+      }
+    });
+  }
+
+  // SAVE button -> POST /upload/image with file + detection_token
+  if (btnSave) {
+    btnSave.addEventListener("click", async () => {
+      if (!window.lastFile) {
+        setStatus(saveStatus, "error", "No file selected.");
+        return;
+      }
+      if (!lastDetectionToken) {
+        setStatus(saveStatus, "error", "No detection token. Run detection first.");
+        return;
+      }
+
+      btnSave.disabled = true;
+      setStatus(saveStatus, "info", "Saving image...");
+
+      const formData = new FormData();
+      formData.append("file", window.lastFile);
+      formData.append("detection_token", lastDetectionToken);
+
+      const isPublic = !!(savePublic && savePublic.checked);
+      formData.append("is_public", isPublic ? "true" : "false");
+
+      try {
+        const res = await fetch("/upload/image", { method: "POST", body: formData });
+        let data = null;
+        try { data = await res.json(); } catch { data = { detail: "Non-JSON response" }; }
+        setDebug({ url: "/upload/image", status: res.status, body: data });
+
+        if (res.ok) {
+          setStatus(saveStatus, "success", "Saved.");
+          if (saveResult) saveResult.textContent = "";
+
+          
+          loadPublicImages();
+        } else {
+          setStatus(saveStatus, "error", data.detail || `Save failed (${res.status})`);
+        }
+      } catch (err) {
+        console.error(err);
+        setStatus(saveStatus, "error", "Network error during save.");
+      } finally {
+        btnSave.disabled = false;
       }
     });
   }
@@ -179,6 +316,9 @@ window.addEventListener("DOMContentLoaded", () => {
     // keep the last response on the card for future actions (if needed)
     if (detectCard) detectCard.latestResponse = resp;
   }
+
+  // load public images on page load
+  loadPublicImages();
 
   // Initial auth/me to populate header user chip (silent if fails)
   (async () => {

--- a/client/static/styles.css
+++ b/client/static/styles.css
@@ -294,3 +294,18 @@ button.secondary {
   .detection-thumb { width: 100%; height: 160px; }
   .detection-main { width: 100%; }
 }
+
+
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.image-grid img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 10px;
+}

--- a/client/templates/imgProcessing.html
+++ b/client/templates/imgProcessing.html
@@ -38,6 +38,20 @@
             hidden
           >
             <div class="detection-row">
+              
+              <img
+                id="preview-image"
+                alt="Selected image preview"
+                style="
+                  width: 120px;
+                  height: 120px;
+                  object-fit: cover;
+                  border-radius: 12px;
+                  flex: 0 0 auto;
+                "
+                hidden
+              />
+
               <div class="detection-main">
                 <p id="detect-verdict" class="verdict-text label-neutral">—</p>
 
@@ -55,6 +69,29 @@
                     >Confidence: —</small
                   >
                 </div>
+
+                
+          <hr class="divider" />
+
+          <h3 class="subheading">Save</h3>
+
+          <label class="row" style="gap: 10px; align-items: center;">
+            <input id="save-public" type="checkbox" />
+            Publish to community (public)
+          </label>
+
+          <div class="row">
+            <button id="btn-save" disabled>Save image</button>
+            <span id="save-state" class="muted">Run detection first to enable saving.</span>
+          </div>
+
+          <div id="save-status" class="status-bar"></div>
+          <div id="save-result" class="muted"></div>
+
+
+
+
+
               </div>
             </div>
           </div>
@@ -71,8 +108,20 @@
         <p class="muted">Debug view. Last JSON response from the server:</p>
         <pre id="debug-output">{}</pre>
       </section>
+
+
+
+      <section class="card">
+        <h2>Community</h2>
+        <div id="public-images" class="image-grid muted">
+          Loading public images…
+        </div>
+      </section>
+
     </main>
 
-    <script src="../static/imageProcessing.js".js"></script>
+    
+
+    <script src="../static/imageProcessing.js"></script>
   </body>
 </html>

--- a/media/main-media.py
+++ b/media/main-media.py
@@ -17,13 +17,11 @@ app = FastAPI()
 
 # ---- env ----
 MONGO_URI = os.getenv("MONGO_URI")
-MONGO_DB = os.getenv("MONGO_DB", "aiclipse")
-
+MONGO_DB =  "aiclipse"
 S3_ENDPOINT = os.getenv("S3_ENDPOINT")
 S3_PUBLIC_ENDPOINT = os.getenv("S3_PUBLIC_ENDPOINT")
-S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY")
-S3_SECRET_KEY = os.getenv("S3_SECRET_KEY")
-S3_BUCKET = os.getenv("S3_BUCKET", "images")
+
+S3_BUCKET = "images"
 
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
 MAX_FILE_SIZE = 5 * 1024 * 1024
@@ -41,8 +39,6 @@ except Exception:
 s3 = boto3.client(
     "s3",
     endpoint_url=S3_ENDPOINT,
-    aws_access_key_id=S3_ACCESS_KEY,
-    aws_secret_access_key=S3_SECRET_KEY,
     region_name=os.getenv("AWS_REGION", "us-east-1"),
 )
 

--- a/media/main-media.py
+++ b/media/main-media.py
@@ -1,105 +1,200 @@
-import os, logging
-import hashlib
-import json
-from fastapi import FastAPI, HTTPException
-from pymongo import MongoClient
-import redis
+import os
+import logging
+from datetime import datetime, timezone
+from uuid import uuid4
+from typing import Optional, Annotated
 
-# Media service: validates uploads, issues upload target, marks asset ready on callback, emits 'media.uploaded'.
+import boto3
+from botocore.exceptions import ClientError
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from pymongo import MongoClient
+from bson import ObjectId
+
+from pydantic import BaseModel, Field, ConfigDict
+from pydantic.functional_serializers import PlainSerializer
 
 app = FastAPI()
 
-# Config
+# ---- env ----
 MONGO_URI = os.getenv("MONGO_URI")
-MONGO_DB = os.getenv("MONGO_DB")
-REDIS_URI = os.getenv("REDIS_URI")
-STREAM = os.getenv("STREAM")
-S3_ENDPOINT = os.getenv("S3_ENDPOINT")            # internal S3 endpoint
-S3_PUBLIC_ENDPOINT = os.getenv("S3_PUBLIC_ENDPOINT")  # public URL base returned to client
+MONGO_DB = os.getenv("MONGO_DB", "aiclipse")
 
-# Optional Mongo store for assets; service stays operational without it
-assets = None
-try:
-    mc = MongoClient(MONGO_URI)
-    mc.admin.command("ping")
-    assets = mc[MONGO_DB].assets
-except Exception:
-    assets = None
+S3_ENDPOINT = os.getenv("S3_ENDPOINT")
+S3_PUBLIC_ENDPOINT = os.getenv("S3_PUBLIC_ENDPOINT")
+S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY")
+S3_SECRET_KEY = os.getenv("S3_SECRET_KEY")
+S3_BUCKET = os.getenv("S3_BUCKET", "images")
 
-# Redis for id generation and eventing
-r = redis.Redis.from_url(REDIS_URI, decode_responses=True)
-
-# Upload constraints
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp"}
 MAX_FILE_SIZE = 5 * 1024 * 1024
 
-@app.post("/media/uploads")
-def create_upload(payload: dict):
-    # Validate minimal contract coming from Gateway
-    name = payload.get("name")
-    content_type = payload.get("contentType")
-    size = payload.get("size")
-    owner_id = payload.get("owner_id")
-    if not name or not content_type or size is None or not owner_id:
-        raise HTTPException(status_code=400, detail="Missing required fields")
-    if content_type not in ALLOWED_TYPES:
-        raise HTTPException(status_code=415, detail="Unsupported Media Type")
-    if size > MAX_FILE_SIZE:
-        raise HTTPException(status_code=413, detail="Payload Too Large")
+# ---- mongo ----
+images = None
+try:
+    mc = MongoClient(MONGO_URI)
+    mc.admin.command("ping")
+    images = mc[MONGO_DB].images
+except Exception:
+    images = None
 
-    # Create asset id and persist if Mongo is available
-    asset_id = f"ast_{r.incr('asset_id_counter')}"
-    if assets is not None:
-        try:
-            assets.insert_one({
-                "asset_id": asset_id,
-                "owner_id": owner_id,
-                "name": name,
-                "contentType": content_type,
-                "size": size,
-                "status": "pending"
-            })
-        except Exception:
-            pass
+# ---- s3 / minio ----
+s3 = boto3.client(
+    "s3",
+    endpoint_url=S3_ENDPOINT,
+    aws_access_key_id=S3_ACCESS_KEY,
+    aws_secret_access_key=S3_SECRET_KEY,
+    region_name=os.getenv("AWS_REGION", "us-east-1"),
+)
 
-    # Return a client-facing upload target
-    key = f"media/uploads/{asset_id}/{name}"
-    upload_url = f"{S3_PUBLIC_ENDPOINT.rstrip('/')}/{key}"  # demo: public URL, not presigned
-    return {"asset_id": asset_id, "uploadUrl": upload_url}
+def ensure_bucket():
+    try:
+        s3.head_bucket(Bucket=S3_BUCKET)
+        return
+    except Exception:
+        pass
+    try:
+        s3.create_bucket(Bucket=S3_BUCKET)
+    except Exception as e:
+        logging.warning("bucket ensure failed: %s", e)
 
-@app.post("/media/storage-callback")
-def storage_callback(payload: dict):
-    # Called by storage after a successful PUT
-    asset_id = payload.get("asset_id")
-    if not asset_id:
-        raise HTTPException(status_code=400, detail="asset_id is required")
-    if assets is None:
-        return {"status": "ok"}
-
-    doc = assets.find_one({"asset_id": asset_id})
-    if not doc:
-        raise HTTPException(status_code=404, detail="Asset not found")
-
-    # Mark asset ready and compute a stable content hash placeholder
-    sha = hashlib.sha256(asset_id.encode()).hexdigest()
-    assets.update_one({"asset_id": asset_id}, {"$set": {"status": "ready", "sha256": sha}})
-
-    # Emit event for consumers with internal S3 URI
-    s3_uri = f"{S3_ENDPOINT.rstrip('/')}/media/uploads/{asset_id}/{doc['name']}"
-    evt = {"asset_id": asset_id, "owner_id": doc["owner_id"], "s3_uri": s3_uri, "sha256": sha}
-    r.xadd(STREAM, {"type": "media.uploaded", "data": json.dumps(evt)})
-    return {"status": "ok"}
-
-class _HealthzFilter(logging.Filter):
-    # Hide /healthz from access logs
-    def filter(self, record):
-        try:
-            return "/healthz" not in record.getMessage()
-        except Exception:
-            return True
-
-logging.getLogger("uvicorn.access").addFilter(_HealthzFilter())
+@app.on_event("startup")
+def _startup():
+    ensure_bucket()
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok"}
+
+# --------------------------------------------------
+# URL helper
+# --------------------------------------------------
+def public_url_for_key(key: str) -> str:
+    base = (S3_PUBLIC_ENDPOINT or "").rstrip("/")
+    return f"{base}/{S3_BUCKET}/{key}"
+
+def attach_url(doc: dict) -> dict:
+    d = dict(doc)
+    key = d.get("s3_key")
+    if key:
+        d["url"] = public_url_for_key(key)
+    return d
+
+# --------------------------------------------------
+# BEST PRACTICE: ObjectId-safe response model
+# --------------------------------------------------
+PyObjectId = Annotated[
+    ObjectId,
+    PlainSerializer(lambda v: str(v), return_type=str),
+]
+
+class ImageOut(BaseModel):
+    id: Optional[PyObjectId] = Field(default=None, alias="_id")
+
+    image_id: str
+    user_id: str
+    s3_key: str
+    verdict: str
+    label: str
+    confidence: float
+    is_public: bool
+    uploaded_at: str
+    is_reported: bool
+    url: Optional[str] = None
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
+# --------------------------------------------------
+
+@app.post("/upload/image", status_code=201, response_model=ImageOut)
+async def upload_image(
+    file: UploadFile = File(...),
+    user_id: str = Form(...),
+    verdict: str = Form(...),
+    label: str = Form(...),
+    confidence: float = Form(...),
+    is_public: bool = Form(...),
+):
+    if file.content_type not in ALLOWED_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported Media Type")
+
+    data = await file.read()
+    if len(data) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="Payload Too Large")
+
+    image_id = f"img_{uuid4().hex}"
+    ext = (
+        ".jpg" if file.content_type == "image/jpeg"
+        else ".png" if file.content_type == "image/png"
+        else ".webp"
+    )
+
+    key = f"{image_id}{ext}"
+
+    try:
+        s3.put_object(
+            Bucket=S3_BUCKET,
+            Key=key,
+            Body=data,
+            ContentType=file.content_type,
+        )
+    except ClientError as e:
+        logging.exception("s3 put_object failed")
+        raise HTTPException(status_code=500, detail="Failed to store image") from e
+
+    doc = {
+        "image_id": image_id,
+        "user_id": user_id,
+        "s3_key": key,
+        "verdict": verdict,
+        "label": label,
+        "confidence": float(confidence),
+        "is_public": bool(is_public),
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        "is_reported": False,
+    }
+
+    if images is not None:
+        try:
+            res = images.insert_one(doc)
+            doc["_id"] = res.inserted_id  # safe: Pydantic serializes it
+        except Exception:
+            logging.exception("mongo insert failed")
+
+    return attach_url(doc)
+
+@app.get("/images")
+def list_images(user_id: str | None = None, is_public: bool | None = None):
+    if images is None:
+        return {"items": []}
+
+    q = {}
+    if user_id is not None:
+        q["user_id"] = user_id
+    if is_public is not None:
+        q["is_public"] = bool(is_public)
+
+    items = list(
+        images.find(q, {"_id": 0})
+        .sort("uploaded_at", -1)
+        .limit(200)
+    )
+
+    items = [attach_url(it) for it in items]
+    return {"items": items}
+
+@app.get("/image/{image_id}")
+def get_image(image_id: str, user_id: str | None = None):
+    if images is None:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    doc = images.find_one({"image_id": image_id}, {"_id": 0})
+    if not doc:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    if (user_id is not None and doc.get("user_id") == user_id) or doc.get("is_public") is True:
+        return attach_url(doc)
+
+    raise HTTPException(status_code=404, detail="Not found")

--- a/media/requirements.txt
+++ b/media/requirements.txt
@@ -4,3 +4,5 @@ pymongo
 redis
 boto3
 python-multipart
+pytest
+httpx

--- a/media/requirements.txt
+++ b/media/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn[standard]
 pymongo
 redis
+boto3
+python-multipart

--- a/media/tests/test_upload_image.py
+++ b/media/tests/test_upload_image.py
@@ -1,0 +1,48 @@
+import io
+import importlib.util
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+# Load FastAPI app from media/main-media.py 
+MEDIA_MAIN = Path(__file__).resolve().parents[1] / "main-media.py"
+spec = importlib.util.spec_from_file_location("main_media", MEDIA_MAIN)
+main_media = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(main_media)
+
+@pytest.fixture()
+def client(monkeypatch):
+    # Mock S3 put_object so no real network/credentials are needed
+    def _fake_put_object(**kwargs):
+        return {"ETag": '"fake-etag"'}
+
+    monkeypatch.setattr(main_media.s3, "put_object", _fake_put_object)
+
+    # stop bucket checks from running if they cause issues
+    monkeypatch.setattr(main_media, "ensure_bucket", lambda: None)
+
+    return TestClient(main_media.app)
+
+def test_upload_image_success(client):
+    fake_image = io.BytesIO(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+    r = client.post(
+        "/upload/image",
+        files={"file": ("test.png", fake_image, "image/png")},
+        data={
+            "user_id": "test_user",
+            "verdict": "ok",
+            "label": "real",
+            "confidence": "0.85",
+            "is_public": "true",
+        },
+    )
+
+    assert r.status_code == 201, r.text
+    body = r.json()
+
+    assert body["image_id"].startswith("img_")
+    assert body["user_id"] == "test_user"
+    assert body["s3_key"].endswith(".png")
+    assert "url" in body  


### PR DESCRIPTION
Implement image upload pipeline with FastAPI, S3 storage, URL generation, and pytest 

- Add a multipart image upload endpoint with checks on image type and size validation
- Store image binaries in MinIO and generate URLs
- stores image url and other related info in images in MongoDB
- Added a check box that if ticked will make the image public and will display any public images below

-Implemented test: add API-level pytest for /upload/image that simulates multipart image upload and asserts successful persistence logic and response fields.

TO DO:
Run Skaffold. Open Minio in the browser. Log in. Click the plus on the left-hand side bar and create a bucket called "images". make sure to upload an image on aiclipse.local and set it as public (.jpg, .png, .webp)

NOTE: 
MinIO buckets are private by default. Because images are loaded directly by the browser using public URLs, MinIO must allow anonymous download access for the images bucket. Without these images cannot be displayed ( but you can still upload). Run these 3 commands below to set it so we can access the images. 


Invoke-WebRequest `https://dl.min.io/client/mc/release/windows-amd64/mc.exe `-OutFile mc.exe ( This command downloads the MinIO client for Windows, which is required to configure bucket permissions. This may take a few minutes)

.\mc.exe alias set local http://127.0.0.1:9000 (minio username) (minio password)

.\mc.exe anonymous set download local/images


<img width="1919" height="413" alt="image" src="https://github.com/user-attachments/assets/2364e7c0-7362-4aab-af17-0b7ea50fdadb" />

<img width="1217" height="650" alt="image" src="https://github.com/user-attachments/assets/783c3348-23b3-46d6-9001-8207e0ceeaf8" />
