### PR TITLE
CD: add OWASP ZAP Full Scan after prod-deploy

### DIFF
--- a/.github/workflows/dast-zap.yml
+++ b/.github/workflows/dast-zap.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  zap-baseline:
-    name: ZAP Baseline (${{ matrix.site.name }})
+  zap-full-scan:
+    name: ZAP Full Scan (${{ matrix.site.name }})
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
@@ -29,16 +29,15 @@ jobs:
             url: https://storage.aiclipse.online
 
     steps:
-      - name: Checkout (only needed if we later add a rules file)
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: OWASP ZAP Baseline scan
-        uses: zaproxy/action-baseline@v0.15.0
+      - name: OWASP ZAP Full Scan (active)
+        uses: zaproxy/action-full-scan@v0.13.0
         with:
           target: ${{ matrix.site.url }}
           docker_name: ghcr.io/zaproxy/zaproxy:stable
           allow_issue_writing: false
-          artifact_name: zap_scan_${{ matrix.site.name }}
-          # -I: do not return failure on warning (keeps CD non-blocking initially)
-          # -m: spider minutes, -T: max time, -s: short output
-          cmd_options: "-I -m 2 -T 10 -s"
+          artifact_name: zap_full_${{ matrix.site.name }}
+          # Stronger than baseline: active scan + optional ajax spider.
+          # -m limits spider minutes; -T limits startup/passive wait; -j enables ajax spider; -I prevents failing on WARN initially.
+          cmd_options: "-m 5 -T 15 -j -I -s"

--- a/.github/workflows/dast-zap.yml
+++ b/.github/workflows/dast-zap.yml
@@ -1,0 +1,44 @@
+name: dast-zap
+
+on:
+  workflow_run:
+    workflows: ["prod-deploy"]
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dast-zap
+  cancel-in-progress: true
+
+jobs:
+  zap-baseline:
+    name: ZAP Baseline (${{ matrix.site.name }})
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        site:
+          - name: app
+            url: https://aiclipse.online
+          - name: storage
+            url: https://storage.aiclipse.online
+
+    steps:
+      - name: Checkout (only needed if we later add a rules file)
+        uses: actions/checkout@v4
+
+      - name: OWASP ZAP Baseline scan
+        uses: zaproxy/action-baseline@v0.15.0
+        with:
+          target: ${{ matrix.site.url }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          allow_issue_writing: false
+          artifact_name: zap_scan_${{ matrix.site.name }}
+          # -I: do not return failure on warning (keeps CD non-blocking initially)
+          # -m: spider minutes, -T: max time, -s: short output
+          cmd_options: "-I -m 2 -T 10 -s"


### PR DESCRIPTION
Add Dynamic Application Security Testing (DAST) to the CD flow using OWASP ZAP Full scan.
The scan runs only after a successful `prod-deploy` completion and targets the public endpoints.

### What changed

- Added new workflow: `.github/workflows/dast-zap.yml`
- Triggers:
  - `workflow_run` after `prod-deploy` completes successfully
  - `workflow_dispatch` for manual runs
- Runs OWASP ZAP scan against:
  - https://aiclipse.online
  - https://storage.aiclipse.online
- Uploads scan reports as workflow artifacts.
- Minimal permissions (`contents: read`). No issue writing.
