### PR TITLE
Community + Redis and Mongo DB operations for Voting

### DIFF
--- a/community/app/components/post/PostBox.jsx
+++ b/community/app/components/post/PostBox.jsx
@@ -22,11 +22,6 @@ export default function PostBox({ image, currentUserId, currentUserName, onVoteU
 
   const isOwner = currentUserId && image?.user_id === currentUserId;
   
-  const [myVote, setMyVote] = useState(image?.user_vote ?? null);
-
-  useEffect(() => {
-    setMyVote(image?.user_vote ?? null);
-  }, [image?.user_vote]);
 
 
 

--- a/community/app/components/post/PostBox.jsx
+++ b/community/app/components/post/PostBox.jsx
@@ -21,6 +21,14 @@ export default function PostBox({ image, currentUserId, currentUserName, onVoteU
   const [isReported, setIsReported] = useState(Boolean(image?.is_reported));
 
   const isOwner = currentUserId && image?.user_id === currentUserId;
+  
+  const [myVote, setMyVote] = useState(image?.user_vote ?? null);
+
+  useEffect(() => {
+    setMyVote(image?.user_vote ?? null);
+  }, [image?.user_vote]);
+
+
 
   useEffect(() => {
     setIsReported(Boolean(image?.is_reported));

--- a/community/app/posts/route.js
+++ b/community/app/posts/route.js
@@ -3,6 +3,9 @@ import { MongoClient } from "mongodb";
 import jwt from "jsonwebtoken";
 import { validateUserId, validateImageId, validatePostId } from "./validation.js";
 
+import { getRedis } from "../../lib/redis.js"
+
+
 export const runtime = "nodejs"; // required for MongoDB driver
 
 const MONGO_URI = process.env.MONGO_URI || "";
@@ -593,9 +596,7 @@ export async function GET() {
   let client = null;
 
   try {
-    if (!MONGO_URI) {
-      throw new Error("MONGO_URI is not set");
-    }
+    if (!MONGO_URI) throw new Error("MONGO_URI is not set");
 
     client = new MongoClient(MONGO_URI);
     await client.connect();
@@ -615,79 +616,59 @@ export async function GET() {
 
     // 2) posts for public images
     const posts = await col
-      .find(
-        { image_id: { $in: publicImageIds } },
-        { projection: { _id: 0 } }
-      )
+      .find({ image_id: { $in: publicImageIds } }, { projection: { _id: 0 } })
       .sort({ created_at: -1 })
       .limit(100)
       .toArray();
 
-    // If no posts, return early
     if (!posts.length) {
       return NextResponse.json({ items: [] }, { status: 200 });
     }
 
-    // 3) vote aggregation (your existing logic)
-    const VOTES_COLLECTION = "community.votes";
-    const votesCol = db.collection(VOTES_COLLECTION);
+    // 3) fetch pending deltas from Redis in one roundtrip
+    const redis = getRedis();
+    const deltaKeys = posts.map((p) => `post:${p.post_id}:vote_deltas`);
 
-    const postIds = posts.map((p) => p.post_id);
+    const pipe = redis.pipeline();
+    for (const k of deltaKeys) pipe.hgetall(k);
+    const pipeRes = await pipe.exec();
 
-    const voteCountsAgg = await votesCol
-      .aggregate([
-        { $match: { post_id: { $in: postIds } } },
-        {
-          $group: {
-            _id: "$post_id",
-            up_vote_count: {
-              $sum: { $cond: [{ $eq: ["$vote", "up"] }, 1, 0] },
-            },
-            down_vote_count: {
-              $sum: { $cond: [{ $eq: ["$vote", "down"] }, 1, 0] },
-            },
-          },
-        },
-      ])
-      .toArray();
-
-    const voteCountsMap = {};
-    for (const vc of voteCountsAgg) {
-      voteCountsMap[vc._id] = {
-        up_vote_count: vc.up_vote_count,
-        down_vote_count: vc.down_vote_count,
+    // Map post_id -> {up, down}
+    const deltasByPostId = {};
+    for (let i = 0; i < posts.length; i++) {
+      const postId = posts[i].post_id;
+      const data = pipeRes?.[i]?.[1] || {};
+      deltasByPostId[postId] = {
+        up: Number(data.up || 0),
+        down: Number(data.down || 0),
       };
     }
 
-    // 4) merge votes into posts
-    const items = posts.map((post) => ({
-      ...post,
-      up_vote_count: voteCountsMap[post.post_id]?.up_vote_count || 0,
-      down_vote_count: voteCountsMap[post.post_id]?.down_vote_count || 0,
-    }));
+    // 4) merge: base counts from posts + pending redis deltas
+    const items = posts.map((post) => {
+      const d = deltasByPostId[post.post_id] || { up: 0, down: 0 };
+      return {
+        ...post,
+        up_vote_count: Number(post.up_vote_count || 0) + d.up,
+        down_vote_count: Number(post.down_vote_count || 0) + d.down,
+      };
+    });
 
     // 5) compute averages for normalization
     const n = items.length || 1;
 
-    const totalClicks = items.reduce(
-      (s, p) => s + safeNumber(p.clicks_count),
-      0
-    );
+    const totalClicks = items.reduce((s, p) => s + safeNumber(p.clicks_count), 0);
     const totalVotes = items.reduce(
       (s, p) => s + safeNumber(p.up_vote_count) + safeNumber(p.down_vote_count),
       0
     );
-    const totalComments = items.reduce(
-      (s, p) => s + safeNumber(p.comment_count),
-      0
-    );
+    const totalComments = items.reduce((s, p) => s + safeNumber(p.comment_count), 0);
 
-    // Avoid divide by 0 by falling back to 1 (demo-style)
     const avgClicks = totalClicks / n || 1;
     const avgVotes = totalVotes / n || 1;
     const avgComments = totalComments / n || 1;
 
-    // 6) scoring constants (from your demo)
+    // 6) scoring constants
     const votesWeight = 0.6;
     const commentsWeight = 0.3;
     const clicksWeight = 0.1;
@@ -707,12 +688,10 @@ export async function GET() {
       const clicksNorm = safeDiv(numClicks, avgClicks);
       const commentsNorm = safeDiv(numComments, avgComments);
 
-      var engagement =
+      const engagement =
         votesNorm * votesWeight +
         clicksNorm * clicksWeight +
         commentsNorm * commentsWeight;
-
-     
 
       const createdAtSec = createdAtToUnixSeconds(post.created_at);
       const ageSeconds = Math.max(nowSec - createdAtSec, 0);
@@ -722,28 +701,16 @@ export async function GET() {
 
       let score = engagement / timeFactor;
 
-      // demo: fresh boost
+      // demo boosts
+      if (engagement === 0 && ageHours < 24) score = Math.max(score, 0.5);
+      if (ageHours < 24) score *= 1.2;
 
-      if (engagement === 0 && ageHours < 24) {
-      score = Math.max(score, 0.5); 
-    }
-
-    if (ageHours < 24) score *= 1.2;
-
-
-      // demo: controversial boost
       if (isControversial(post, nowSec)) score *= 2.5;
 
       return {
         ...post,
-        score, // NEW: included for sorting + optional UI debug
-        debug: {
-          votesNorm,
-          clicksNorm,
-          commentsNorm,
-          engagement,
-          ageHours,
-        },
+        score,
+        debug: { votesNorm, clicksNorm, commentsNorm, engagement, ageHours },
       };
     });
 
@@ -766,4 +733,3 @@ export async function GET() {
     }
   }
 }
-

--- a/community/app/posts/vote/route.js
+++ b/community/app/posts/vote/route.js
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
 import jwt from "jsonwebtoken";
 import { validateUserId, validatePostId } from "../validation.js";
+import { getRedis } from "../../../lib/redis.js";
 
-export const runtime = "nodejs"; 
+export const runtime = "nodejs";
 
 const MONGO_URI = process.env.MONGO_URI || "";
 const MONGO_DB = process.env.MONGO_DB || "aiclipse";
@@ -11,11 +12,13 @@ const MONGO_DB = process.env.MONGO_DB || "aiclipse";
 const POSTS_COLLECTION = "community.posts";
 const VOTES_COLLECTION = "community.votes";
 
-// Helper function to extract and verify JWT token from Authorization header or cookie
+const FLUSH_ZSET = "votes:flush_at";
+const FLUSH_DEBOUNCE_MS = 120_000; // 2 minutes
+const DELTA_TTL_SECONDS = 60 * 60; // safety TTL 1 hour
+
 function getAuthenticatedUserId(req) {
   let token = null;
-  
-  // Try Authorization header first
+
   const authHeader = req.headers.get("authorization");
   if (authHeader) {
     const parts = authHeader.split(" ");
@@ -23,53 +26,38 @@ function getAuthenticatedUserId(req) {
       token = parts[1];
     }
   }
-  
-  // Fallback to cookie if no Authorization header
+
   if (!token) {
     const cookieHeader = req.headers.get("cookie");
     if (cookieHeader) {
       const cookies = Object.fromEntries(
-        cookieHeader.split("; ").map(c => {
+        cookieHeader.split("; ").map((c) => {
           const [key, ...v] = c.split("=");
           return [key, v.join("=")];
-        })
+        }),
       );
       token = cookies.access_token;
     }
   }
-  
-  if (!token) {
-    throw new Error("Missing authentication token");
-  }
-  
-  try {
-    // Decode without verification to get the user_id
-    // In production, you should verify the JWT signature using the public key from auth service
-    const decoded = jwt.decode(token);
-    
-    if (!decoded || !decoded.sub) {
-      throw new Error("Invalid token payload");
-    }
-    
-    return decoded.sub; // user_id is stored in 'sub' claim
-  } catch (err) {
-    throw new Error("Invalid or expired token");
-  }
-}
 
+  if (!token) throw new Error("Missing authentication token");
+
+  const decoded = jwt.decode(token);
+  if (!decoded || !decoded.sub) throw new Error("Invalid token payload");
+  return decoded.sub;
+}
 
 export async function POST(req) {
   let client = null;
 
   try {
-    // Verify authentication and get authenticated user_id from JWT token
     let authenticatedUserId;
     try {
       authenticatedUserId = getAuthenticatedUserId(req);
     } catch (authErr) {
       return NextResponse.json(
         { error: "Unauthorized", detail: String(authErr) },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -77,49 +65,36 @@ export async function POST(req) {
 
     const post_id = body?.post_id || null;
     const user_id = body?.user_id || null;
-    const vote = body?.vote || null; 
+    const vote = body?.vote || null;
 
-    // basic validation
     if (!post_id || !user_id || (vote !== "up" && vote !== "down")) {
       return NextResponse.json(
         { error: "Missing/invalid fields: post_id, user_id, vote('up'|'down')" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // validate user_id format
     const userIdValidation = validateUserId(user_id);
     if (!userIdValidation.valid) {
-      return NextResponse.json(
-        { error: userIdValidation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: userIdValidation.error }, { status: 400 });
     }
-    const safeUserId = userIdValidation.value; // Use sanitized string value
+    const safeUserId = userIdValidation.value;
 
-    // validate post_id format
     const postIdValidation = validatePostId(post_id);
     if (!postIdValidation.valid) {
-      return NextResponse.json(
-        { error: postIdValidation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: postIdValidation.error }, { status: 400 });
     }
-    const safePostId = postIdValidation.value; // Use sanitized string value
+    const safePostId = postIdValidation.value;
 
-    // Security check: ensure user_id in request matches authenticated user
     if (safeUserId !== authenticatedUserId) {
       return NextResponse.json(
         { error: "Forbidden: Cannot vote on behalf of other users" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
-    if (!MONGO_URI) {
-      throw new Error("MONGO_URI is not set");
-    }
+    if (!MONGO_URI) throw new Error("MONGO_URI is not set");
 
-    // connect to Mongo 
     client = new MongoClient(MONGO_URI);
     await client.connect();
 
@@ -127,75 +102,109 @@ export async function POST(req) {
     const posts = db.collection(POSTS_COLLECTION);
     const votes = db.collection(VOTES_COLLECTION);
 
-    // make sure post exists
-    const postExists = await posts.findOne(
+    // Ensure post exists
+    const postDoc = await posts.findOne(
       { post_id: safePostId },
-      { projection: { _id: 0, post_id: 1 } }
+      { projection: { _id: 0, post_id: 1, up_vote_count: 1, down_vote_count: 1 } },
     );
-    if (!postExists) {
+    if (!postDoc) {
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
 
     const now = new Date();
 
-    // Atomic operation: upsert vote and get old value to determine count changes
-    // This prevents race conditions by handling the entire vote logic in a single operation
-    const voteResult = await votes.findOneAndUpdate(
+
+    const existing = await votes.findOne(
       { post_id: safePostId, user_id: safeUserId },
-      {
-        $set: { vote, updated_at: now },
-        $setOnInsert: { created_at: now }
-      },
-      {
-        upsert: true,
-        returnDocument: "before", // get old value to know what changed
-        projection: { _id: 0, vote: 1 }
-      }
+      { projection: { _id: 1, vote: 1 } },
     );
 
-    const oldVote = voteResult?.value?.vote; // undefined if new vote, "up" or "down" if existing
+    const oldVote = existing?.vote; // undefined | "up" | "down"
+    let newUserVote = null; // null | "up" | "down"
 
-    // Don't update post counts - they should be calculated from votes collection
-    // The GET endpoint will aggregate the real counts from community.votes
-    
-    // Calculate actual vote counts from the votes collection (source of truth)
-    const actualCounts = await votes.aggregate([
-      { $match: { post_id: safePostId } },
-      {
-        $group: {
-          _id: null,
-          up_vote_count: {
-            $sum: { $cond: [{ $eq: ["$vote", "up"] }, 1, 0] }
-          },
-          down_vote_count: {
-            $sum: { $cond: [{ $eq: ["$vote", "down"] }, 1, 0] }
-          }
-        }
-      }
-    ]).toArray();
+    // Compute deltas based on Reddit rules:
+    // - none -> up/down  : +1
+    // - up -> up         : remove => -1
+    // - down -> down     : remove => -1
+    // - up -> down       : up -1, down +1
+    // - down -> up       : down -1, up +1
+    let deltaUp = 0;
+    let deltaDown = 0;
 
-    const upCount = actualCounts[0]?.up_vote_count ?? 0;
-    const downCount = actualCounts[0]?.down_vote_count ?? 0;
+    if (!existing) {
+      // create vote
+      await votes.insertOne({
+        post_id: safePostId,
+        user_id: safeUserId,
+        vote,
+        created_at: now,
+        updated_at: now,
+      });
+      newUserVote = vote;
+      if (vote === "up") deltaUp = 1;
+      else deltaDown = 1;
+    } else if (oldVote === vote) {
+      // toggle off -> delete vote doc
+      await votes.deleteOne({ _id: existing._id });
+      newUserVote = null;
+      if (oldVote === "up") deltaUp = -1;
+      else deltaDown = -1;
+    } else {
+      // switch vote
+      await votes.updateOne(
+        { _id: existing._id },
+        { $set: { vote, updated_at: now } },
+      );
+      newUserVote = vote;
+
+      if (oldVote === "up") deltaUp -= 1;
+      if (oldVote === "down") deltaDown -= 1;
+      if (vote === "up") deltaUp += 1;
+      if (vote === "down") deltaDown += 1;
+    }
+
+    // Buffer deltas in Redis and debounce flush
+    const redis = getRedis();
+    const deltaKey = `post:${safePostId}:vote_deltas`;
+    const flushAtSec = Math.floor((Date.now() + FLUSH_DEBOUNCE_MS) / 1000);
+
+    if (deltaUp !== 0 || deltaDown !== 0) {
+      const pipe = redis.pipeline();
+      if (deltaUp !== 0) pipe.hincrby(deltaKey, "up", deltaUp);
+      if (deltaDown !== 0) pipe.hincrby(deltaKey, "down", deltaDown);
+
+      pipe.zadd(FLUSH_ZSET, flushAtSec, safePostId);
+      pipe.expire(deltaKey, DELTA_TTL_SECONDS);
+      await pipe.exec();
+    }
+
+    // Return "current" counts fast: base counts from posts + pending redis deltas
+    const pending = await redis.hgetall(deltaKey);
+    const pendingUp = Number(pending?.up || 0);
+    const pendingDown = Number(pending?.down || 0);
+
+    const baseUp = Number(postDoc?.up_vote_count || 0);
+    const baseDown = Number(postDoc?.down_vote_count || 0);
 
     return NextResponse.json(
       {
-        post_id,
-        up_vote_count: Number(upCount),
-        down_vote_count: Number(downCount),
-        ...(oldVote === vote && { message: "Vote already recorded" })
+        post_id: safePostId,
+        up_vote_count: baseUp + pendingUp,
+        down_vote_count: baseDown + pendingDown,
+        user_vote: newUserVote, 
       },
-      { status: 200 }
+      { status: 200 },
     );
   } catch (err) {
- 
     return NextResponse.json(
       { error: "Failed to vote", detail: String(err) },
-      { status: 500 }
+      { status: 500 },
     );
   } finally {
- 
     if (client) {
-      try { await client.close(); } catch {}
+      try {
+        await client.close();
+      } catch {}
     }
   }
 }

--- a/community/app/styles/postBox.css
+++ b/community/app/styles/postBox.css
@@ -226,3 +226,41 @@
 .muted {
   opacity: 0.6;
 }
+
+.voteActive {
+  outline: 2px solid rgba(255,255,255,0.25);
+}
+
+
+.comm_voteUp.active {
+  background-color: #4caf50;
+  color: white;
+}
+
+.comm_voteDown.active {
+  background-color: #f44336; 
+  color: white;
+}
+
+
+.comm_voteBlock {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.comm_voteMeta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.comm_voteNumber {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.comm_voteLabel {
+  font-size: 11px;
+  opacity: 0.7;
+}

--- a/community/package-lock.json
+++ b/community/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "community",
       "dependencies": {
+        "ioredis": "^5.9.2",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.21.0",
         "next": "^15.0.0",
@@ -463,6 +464,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "license": "MIT"
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.5.tgz",
@@ -654,6 +661,41 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -669,6 +711,30 @@
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
+      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/js-tokens": {
@@ -716,10 +782,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -979,6 +1057,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1076,6 +1175,12 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "4.1.1",
@@ -1307,6 +1412,11 @@
       "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "optional": true
     },
+    "@ioredis/commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="
+    },
     "@mongodb-js/saslprep": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.5.tgz",
@@ -1409,6 +1519,24 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+    },
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1421,6 +1549,22 @@
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "ioredis": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
+      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
+      "requires": {
+        "@ioredis/commands": "1.5.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
       }
     },
     "js-tokens": {
@@ -1464,10 +1608,20 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -1609,6 +1763,19 @@
         "scheduler": "^0.23.2"
       }
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1674,6 +1841,11 @@
       "requires": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "tr46": {
       "version": "4.1.1",

--- a/community/package.json
+++ b/community/package.json
@@ -7,6 +7,7 @@
     "start": "next start -H 0.0.0.0 -p 3000"
   },
   "dependencies": {
+    "ioredis": "^5.9.2",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.21.0",
     "next": "^15.0.0",

--- a/community/voteFlushWorker.js
+++ b/community/voteFlushWorker.js
@@ -1,0 +1,91 @@
+import { MongoClient } from "mongodb";
+import { getRedis } from "./lib/redis.js"
+
+const MONGO_URI = process.env.MONGO_URI || "";
+const MONGO_DB = process.env.MONGO_DB || "aiclipse";
+const POSTS_COLLECTION = "community.posts";
+
+const FLUSH_ZSET = "votes:flush_at";
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function flushOnce({ redis, posts }) {
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  // PuLL IDS
+  const duePostIds = await redis.zrangebyscore(FLUSH_ZSET, "-inf", nowSec, "LIMIT", 0, 200);
+  if (!duePostIds.length) return 0;
+
+  for (const postId of duePostIds) {
+    const postKey = `post:${postId}:vote_deltas`;
+
+    //   only one worker flushes a post at a time
+    const lockKey = `lock:flush:${postId}`;
+    const gotLock = await redis.set(lockKey, "1", "NX", "EX", 30);
+    if (!gotLock) continue;
+
+    try {
+      // Re-check that it's still due (in case a new vote extended flush_at)
+      const score = await redis.zscore(FLUSH_ZSET, postId);
+      if (!score || Number(score) > nowSec) continue;
+
+      const deltas = await redis.hgetall(postKey);
+      const deltaUp = Number(deltas?.up || 0);
+      const deltaDown = Number(deltas?.down || 0);
+
+      if (deltaUp !== 0 || deltaDown !== 0) {
+        await posts.updateOne(
+          { post_id: postId },
+          {
+            $inc: {
+              ...(deltaUp ? { up_vote_count: deltaUp } : {}),
+              ...(deltaDown ? { down_vote_count: deltaDown } : {}),
+            },
+            $set: { updated_at: new Date() },
+          }
+        );
+      }
+
+      // Clear redis state after successful flush
+      const pipe = redis.pipeline();
+      pipe.del(postKey);
+      pipe.zrem(FLUSH_ZSET, postId);
+      await pipe.exec();
+    } finally {
+      await redis.del(lockKey);
+    }
+  }
+
+  return duePostIds.length;
+}
+
+async function main() {
+  if (!MONGO_URI) throw new Error("MONGO_URI is not set");
+
+  const redis = getRedis();
+  const mongo = new MongoClient(MONGO_URI);
+
+  await mongo.connect();
+  const db = mongo.db(MONGO_DB);
+  const posts = db.collection(POSTS_COLLECTION);
+
+  console.log("[voteFlushWorker] started");
+
+  while (true) {
+    try {
+      const n = await flushOnce({ redis, posts });
+      // if flushed something, loop quickly; otherwise back off
+      await sleep(n ? 250 : 1000);
+    } catch (e) {
+      console.error("[voteFlushWorker] error:", e?.message || e);
+      await sleep(1000);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("[voteFlushWorker] fatal:", e);
+  process.exit(1);
+});

--- a/infra/k8s/community-depl.yaml
+++ b/infra/k8s/community-depl.yaml
@@ -19,6 +19,16 @@ spec:
             - name: GATEWAY_URI
               value: http://gateway-srv:8080
 
+            - name: REDIS_HOST
+              value: redis-srv
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-sec
+                  key: REDIS_PASSWORD
+
           ports: [{ name: http, containerPort: 3000 }]
 
           readinessProbe:

--- a/infra/k8s/community-flush-worker-depl.yaml
+++ b/infra/k8s/community-flush-worker-depl.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: community-vote-worker-depl
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: community-vote-worker } }
+  template:
+    metadata: { labels: { app: community-vote-worker } }
+    spec:
+      containers:
+        - name: worker
+          image: aiclipse/community
+          command: ["node", "voteFlushWorker.js"]
+          env:
+            - name: MONGO_URI
+              valueFrom: { secretKeyRef: { name: mongo-sec, key: MONGO_URI } }
+            - name: MONGO_DB
+              valueFrom: { secretKeyRef: { name: mongo-sec, key: MONGO_DB } }
+
+            - name: REDIS_HOST
+              value: redis-srv
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-sec
+                  key: REDIS_PASSWORD

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   #- k8s/observer-depl.yaml
   - k8s/client-depl.yaml
   - k8s/community-depl.yaml
+  - k8s/community-flush-worker-depl.yaml
   - k8s-dev/ingress-srv.yaml
   - k8s/model-cycle-pvc.yaml
   - k8s/app-configmap.yaml


### PR DESCRIPTION
To test it:

1 choose one post in community
2 find that post in mongoDB
2.1 mark down the up/down vote count
3 on community, add/modify your vote to the post
4 wait for 2 minutes
5 see in mongo DB or in community after refreshing the page that the post vote counts are updated


If youre interested in what this does:

**Pattern: Write-behind cache (Redis buffers writes, DB updated later)**

In this Pr, I'm adding on to the current approach where community creates a community.votes document in MongoDB. MongoDB stays the source of truth, therefore if a user votes on a post, community.votes still creates an item. However, if there's any changes, e.g. user removes downvote, the change first goes to Redis, where there's a 2 minute timer, and if there's no more changes at the post mongo DB gets updated (both community.votes and community.post counts).

Imagine if 200 people put their votes on a post within 2 minutes. instead of updating the community.post 200 times, we do it once at the end of 2 minute span. It handles both initial voting and vote changes efficiently.


**This will have a big effect when working with post clicks, and comments as well.**


Scheme:

<img width="621" height="453" alt="image" src="https://github.com/user-attachments/assets/f873e8a7-44f9-4a61-95ac-918518db0055" />



Background Worker (loop)
ZRANGEBYSCORE votes:flush_at <= now
For each post due:
    >read hash deltas
    >MongoDB: community.posts $inc up/down
    >delete hash + zrem zset



Feed Read: GET /community/posts

MongoDB: read community.posts (cached counts)
Redis: fetch pending deltas in pipeline
Return: up/down = posts + redis pending


