### PR TITLE
PR for community clicks flush worker

### DIFF
--- a/community/app/posts/click/route.js
+++ b/community/app/posts/click/route.js
@@ -1,17 +1,20 @@
 import { NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
 import { validateUserId, validatePostId } from "../validation.js";
+import { getRedis } from "../../../redis/redis.js"
 
-export const runtime = "nodejs"; // required for MongoDB driver
+export const runtime = "nodejs";
 
 const MONGO_URI = process.env.MONGO_URI || "";
 const MONGO_DB = process.env.MONGO_DB || "aiclipse";
 const POSTS_COLLECTION = "community.posts";
-const CLICKS_COLLECTION = "community.clicks";
 
-// Rate limit: only count one click per user per post within this time window
-const CLICK_COOLDOWN_MS = 60 * 1000; // 1 minute
+const FLUSH_ZSET = "clicks:flush_at";
+const FLUSH_DEBOUNCE_MS = 60_000; 
+const DELTA_TTL_SECONDS = 60 * 60; // safety TTL 1 hour
 
+// Rate limit: only count one click per user per post within this window
+const CLICK_COOLDOWN_SECONDS = 60; 
 
 export async function POST(req) {
   let client = null;
@@ -21,114 +24,79 @@ export async function POST(req) {
     const post_id = body?.post_id || null;
     const user_id = body?.user_id || null;
 
-    // basic validation
     if (!post_id) {
       return NextResponse.json({ error: "Missing post_id" }, { status: 400 });
     }
 
-    // validate post_id format
     const postIdValidation = validatePostId(post_id);
     if (!postIdValidation.valid) {
-      return NextResponse.json(
-        { error: postIdValidation.error },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: postIdValidation.error }, { status: 400 });
     }
-    const safePostId = postIdValidation.value; // Use sanitized string value
+    const safePostId = postIdValidation.value;
 
-    // validate user_id format if provided
     let safeUserId = null;
     if (user_id) {
       const userIdValidation = validateUserId(user_id);
       if (!userIdValidation.valid) {
-        return NextResponse.json(
-          { error: userIdValidation.error },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: userIdValidation.error }, { status: 400 });
       }
-      safeUserId = userIdValidation.value; // Use sanitized string value
+      safeUserId = userIdValidation.value;
     }
 
-    // user_id is optional, but if provided enables rate limiting
-    if (!MONGO_URI) {
-      throw new Error("MONGO_URI is not set");
-    }
+    if (!MONGO_URI) throw new Error("MONGO_URI is not set");
 
+    // Ensure post exists (Mongo source of truth)
     client = new MongoClient(MONGO_URI);
     await client.connect();
-
     const db = client.db(MONGO_DB);
     const posts = db.collection(POSTS_COLLECTION);
-    const clicks = db.collection(CLICKS_COLLECTION);
 
-    let shouldIncrement = true;
-
-    // If user_id provided, check rate limiting
-    if (safeUserId) {
-      const now = new Date();
-      const cooldownThreshold = new Date(now.getTime() - CLICK_COOLDOWN_MS);
-
-      // Check if user recently clicked this post
-      const recentClick = await clicks.findOne({
-        post_id: safePostId,
-        user_id: safeUserId,
-        clicked_at: { $gte: cooldownThreshold }
-      });
-
-      if (recentClick) {
-        // User clicked too recently, don't increment
-        shouldIncrement = false;
-      } else {
-        // Record this click with upsert to track user's last click time
-        await clicks.updateOne(
-          { post_id: safePostId, user_id: safeUserId },
-          {
-            $set: { clicked_at: now },
-            $setOnInsert: { created_at: now }
-          },
-          { upsert: true }
-        );
-      }
-    }
-
-    // Increment click count only if rate limit passed (or no user_id provided)
-    let result;
-    if (shouldIncrement) {
-      result = await posts.findOneAndUpdate(
-        { post_id: safePostId },
-        { $inc: { clicks_count: 1 } },
-        {
-          returnDocument: "after",
-          projection: { _id: 0, clicks_count: 1 },
-        }
-      );
-    } else {
-      // Just fetch current count without incrementing
-      result = await posts.findOne(
-        { post_id: safePostId },
-        { projection: { _id: 0, clicks_count: 1 } }
-      );
-      result = { value: result };
-    }
-
-    if (!result.value) {
+    const postDoc = await posts.findOne(
+      { post_id: safePostId },
+      { projection: { _id: 0, post_id: 1, clicks_count: 1 } }
+    );
+    if (!postDoc) {
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
 
+    const redis = getRedis();
+
+    // Rate limit in Redis (only if user_id provided)
+    let counted = true;
+    if (safeUserId) {
+      const rlKey = `click:cooldown:${safePostId}:${safeUserId}`;
+      // SET key 1 NX EX 60 => only first click in window counts
+      const ok = await redis.set(rlKey, "1", "NX", "EX", CLICK_COOLDOWN_SECONDS);
+      if (!ok) counted = false;
+    }
+
+    const deltaKey = `post:${safePostId}:click_deltas`;
+    const flushAtSec = Math.floor((Date.now() + FLUSH_DEBOUNCE_MS) / 1000);
+
+    if (counted) {
+      const pipe = redis.pipeline();
+      pipe.hincrby(deltaKey, "count", 1);
+      pipe.zadd(FLUSH_ZSET, flushAtSec, safePostId);
+      pipe.expire(deltaKey, DELTA_TTL_SECONDS);
+      await pipe.exec();
+    }
+
+    // Return current count fast: base + pending delta
+    const pending = await redis.hget(deltaKey, "count");
+    const pendingCount = Number(pending || 0);
+    const base = Number(postDoc.clicks_count || 0);
+
     return NextResponse.json(
       {
-        post_id,
-        clicks_count: result.value.clicks_count,
-        counted: shouldIncrement
+        post_id: safePostId,
+        clicks_count: base + pendingCount,
+        counted,
       },
       { status: 200 }
     );
   } catch (err) {
     return NextResponse.json(
-      {
-        error: "Failed to increment clicks",
-        detail: String(err),
-      },
+      { error: "Failed to increment clicks", detail: String(err) },
       { status: 500 }
     );
   } finally {
@@ -139,4 +107,3 @@ export async function POST(req) {
     }
   }
 }
-

--- a/community/app/posts/click/route.js
+++ b/community/app/posts/click/route.js
@@ -10,7 +10,7 @@ const MONGO_DB = process.env.MONGO_DB || "aiclipse";
 const POSTS_COLLECTION = "community.posts";
 
 const FLUSH_ZSET = "clicks:flush_at";
-const FLUSH_DEBOUNCE_MS = 60_000; 
+const FLUSH_DEBOUNCE_MS = 30_000; 
 const DELTA_TTL_SECONDS = 60 * 60; // safety TTL 1 hour
 
 // Rate limit: only count one click per user per post within this window

--- a/community/clickFlushWorker.js
+++ b/community/clickFlushWorker.js
@@ -28,17 +28,14 @@ async function flushOnce({ redis, posts }) {
   for (const postId of duePostIds) {
     const deltaKey = `post:${postId}:click_deltas`;
 
-    // Only one worker flushes a post at a time
     const lockKey = `lock:flush:clicks:${postId}`;
     const gotLock = await redis.set(lockKey, "1", "NX", "EX", 30);
     if (!gotLock) continue;
 
     try {
-      // Re-check still due
       const score = await redis.zscore(FLUSH_ZSET, postId);
       if (!score || Number(score) > nowSec) continue;
 
-      // We store a single integer field "count"
       const raw = await redis.hget(deltaKey, "count");
       const delta = Number(raw || 0);
 
@@ -52,7 +49,6 @@ async function flushOnce({ redis, posts }) {
         );
       }
 
-      // Clear redis state after successful flush
       const pipe = redis.pipeline();
       pipe.del(deltaKey);
       pipe.zrem(FLUSH_ZSET, postId);

--- a/community/clickFlushWorker.js
+++ b/community/clickFlushWorker.js
@@ -1,0 +1,94 @@
+import { MongoClient } from "mongodb";
+import { getRedis } from "./redis/redis.js"
+
+const MONGO_URI = process.env.MONGO_URI || "";
+const MONGO_DB = process.env.MONGO_DB || "aiclipse";
+const POSTS_COLLECTION = "community.posts";
+
+const FLUSH_ZSET = "clicks:flush_at";
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function flushOnce({ redis, posts }) {
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  // Pull due post IDs
+  const duePostIds = await redis.zrangebyscore(
+    FLUSH_ZSET,
+    "-inf",
+    nowSec,
+    "LIMIT",
+    0,
+    400
+  );
+  if (!duePostIds.length) return 0;
+
+  for (const postId of duePostIds) {
+    const deltaKey = `post:${postId}:click_deltas`;
+
+    // Only one worker flushes a post at a time
+    const lockKey = `lock:flush:clicks:${postId}`;
+    const gotLock = await redis.set(lockKey, "1", "NX", "EX", 30);
+    if (!gotLock) continue;
+
+    try {
+      // Re-check still due
+      const score = await redis.zscore(FLUSH_ZSET, postId);
+      if (!score || Number(score) > nowSec) continue;
+
+      // We store a single integer field "count"
+      const raw = await redis.hget(deltaKey, "count");
+      const delta = Number(raw || 0);
+
+      if (delta !== 0) {
+        await posts.updateOne(
+          { post_id: postId },
+          {
+            $inc: { clicks_count: delta },
+            $set: { updated_at: new Date() },
+          }
+        );
+      }
+
+      // Clear redis state after successful flush
+      const pipe = redis.pipeline();
+      pipe.del(deltaKey);
+      pipe.zrem(FLUSH_ZSET, postId);
+      await pipe.exec();
+    } finally {
+      await redis.del(lockKey);
+    }
+  }
+
+  return duePostIds.length;
+}
+
+async function main() {
+  if (!MONGO_URI) throw new Error("MONGO_URI is not set");
+
+  const redis = getRedis();
+  const mongo = new MongoClient(MONGO_URI);
+
+  await mongo.connect();
+  const db = mongo.db(MONGO_DB);
+  const posts = db.collection(POSTS_COLLECTION);
+
+  console.log("[clickFlushWorker] started");
+
+  while (true) {
+    try {
+      const n = await flushOnce({ redis, posts });
+      await sleep(n ? 250 : 1000);
+    } catch (e) {
+      console.error("[clickFlushWorker] error:", e?.message || e);
+      await sleep(1000);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("[clickFlushWorker] fatal:", e);
+  process.exit(1);
+});

--- a/infra/k8s/click-flush-depl.yaml
+++ b/infra/k8s/click-flush-depl.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: click-flush-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: community-click-worker
+  template:
+    metadata:
+      labels:
+        app: community-click-worker
+    spec:
+      containers:
+        - name: worker
+          image: aiclipse/community
+          command: ["node", "clickFlushWorker.js"]
+          env:
+            - name: MONGO_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-sec
+                  key: MONGO_URI
+            - name: MONGO_DB
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-sec
+                  key: MONGO_DB
+            - name: REDIS_HOST
+              value: redis-srv
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-sec
+                  key: REDIS_PASSWORD

--- a/infra/k8s/vote-flush-depl.yaml
+++ b/infra/k8s/vote-flush-depl.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: community-vote-worker-depl
+  name: vote-flush-depl
 spec:
   replicas: 1
   selector: { matchLabels: { app: community-vote-worker } }

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -16,7 +16,8 @@ resources:
   #- k8s/observer-depl.yaml
   - k8s/client-depl.yaml
   - k8s/community-depl.yaml
-  - k8s/community-flush-worker-depl.yaml
+  - k8s/click-flush-depl.yaml
+  - k8s/vote-flush-depl.yaml
   - k8s-dev/ingress-srv.yaml
   - k8s/model-cycle-pvc.yaml
   - k8s/app-configmap.yaml


### PR DESCRIPTION
If user clicks on a post, their click will go to the Redis. If there's no updates for that post in 60 seconds, the changes get pushed to mongoDB. Only count one click per user per post within 60 seconds to stop the spamming and algorithm manipulation.

To test:

1. go to community Mongo DB
2. find a post and track its clicks_count
3. click on it on aiclipse.local/community
4. in 30 seconds clicks_count should change:
<img width="409" height="271" alt="image" src="https://github.com/user-attachments/assets/d0717500-8368-4eef-9fc9-931227d21890" />

Later on, we'll change the timings, for testing its 30 sec.
