### PR TITLE
added unit tests for client javascript , html , css

### DIFF
--- a/client/static/js/scans.js
+++ b/client/static/js/scans.js
@@ -243,7 +243,18 @@ async function loadScans() {
   }
 }
 
-window.addEventListener("DOMContentLoaded", () => {
-  // Setup tabs has been removed completely! Just load data.
-  loadScans();
-});
+if (typeof window !== "undefined") {
+  window.addEventListener("DOMContentLoaded", () => {
+    // Setup tabs has been removed completely! Just load data.
+    loadScans();
+  });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    getVisibility,
+    clamp01,
+    cleanLabelText,
+    computeRealPct,
+  };
+}

--- a/client/tests/scans.logic.test.js
+++ b/client/tests/scans.logic.test.js
@@ -1,0 +1,92 @@
+const {
+  getVisibility,
+  clamp01,
+  cleanLabelText,
+  computeRealPct,
+} = require("../static/js/scans.js");
+
+// These tests validate the core scan-page helper logic.
+describe("client scans JavaScript logic", () => {
+  // We show private/public badges based on this value so we need to test a safe default matters.
+  test("getVisibility returns public/private and defaults to private", () => {
+    expect(getVisibility({ is_public: true })).toBe("public");
+    expect(getVisibility({ is_public: false })).toBe("private");
+    expect(getVisibility({})).toBe("private");
+    expect(getVisibility(null)).toBe("private");
+  });
+
+  // Confidence values should always stay in the valid probability range.
+  test("clamp01 keeps values in 0..1", () => {
+    expect(clamp01(0.4)).toBe(0.4);
+    expect(clamp01(-1)).toBe(0);
+    expect(clamp01(2)).toBe(1);
+    expect(clamp01("bad")).toBe(0);
+  });
+
+  // Labels sometimes arrive with a leading percentage (e.g., "87% AI").
+  // This helper removes that prefix so UI text is cleaner.
+  test("cleanLabelText strips leading percent prefix", () => {
+    expect(cleanLabelText("87.74% AI Generated")).toBe("AI Generated");
+    expect(cleanLabelText("  12%   REAL")).toBe("REAL");
+    expect(cleanLabelText("Unknown")).toBe("Unknown");
+  });
+
+  // Null/empty input should not throw and should produce empty text.
+  test("cleanLabelText handles empty-like values safely", () => {
+    expect(cleanLabelText("")).toBe("");
+    expect(cleanLabelText(null)).toBe("");
+    expect(cleanLabelText(undefined)).toBe("");
+  });
+
+  // For AI-like verdicts, "real %" is the inverse of model confidence.
+  test("computeRealPct computes real percentage for AI-like verdicts", () => {
+    const out = computeRealPct({ label: "AI Generated", confidence: 0.8 });
+    expect(out.label).toBe("AI Generated");
+    expect(out.realPct).toBe("20.00");
+  });
+
+  // For a Real verdict, real % follows the confidence directly.
+  test("computeRealPct computes real percentage for real verdicts", () => {
+    const out = computeRealPct({ label: "Real", confidence: 0.91 });
+    expect(out.label).toBe("Real");
+    expect(out.realPct).toBe("91.00");
+  });
+
+  // Some responses send score instead of confidence.
+  // This checks the fallback path still computes correct output.
+  test("computeRealPct falls back to score when confidence is missing", () => {
+    const out = computeRealPct({ result: "Deepfake", score: 0.33 });
+    expect(out.label).toBe("Deepfake");
+    expect(out.realPct).toBe("67.00");
+  });
+
+  // Unknown labels are treated as AI-like by current product logic.
+  test("computeRealPct treats unknown verdict as inverse confidence", () => {
+    const out = computeRealPct({ label: "Maybe", confidence: 0.4 });
+    expect(out.label).toBe("Maybe");
+    expect(out.realPct).toBe("60.00");
+  });
+
+  // Inputs outside [0,1] are clamped before computing percentages.
+  test("computeRealPct clamps out-of-range confidence values", () => {
+    const tooHigh = computeRealPct({ label: "Real", confidence: 2 });
+    const tooLow = computeRealPct({ label: "AI", confidence: -1 });
+
+    expect(tooHigh.realPct).toBe("100.00");
+    expect(tooLow.realPct).toBe("100.00");
+  });
+
+  // Leading percent text should be removed before label classification.
+  test("computeRealPct classifies using cleaned label text", () => {
+    const out = computeRealPct({ label: "75% REAL", confidence: 0.25 });
+    expect(out.label).toBe("REAL");
+    expect(out.realPct).toBe("25.00");
+  });
+
+  // With no label/result and no confidence/score, function should stay stable.
+  test("computeRealPct defaults to Unknown and safe numeric output", () => {
+    const out = computeRealPct({});
+    expect(out.label).toBe("Unknown");
+    expect(out.realPct).toBe("100.00");
+  });
+});

--- a/client/tests/scans.styles.test.js
+++ b/client/tests/scans.styles.test.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+
+describe("scans CSS contract", () => {
+  const cssPath = path.join(__dirname, "../static/css/scans.css");
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  // Core layout and hover behavior should always be present.
+  test("has scan card interactions and grid layout selectors", () => {
+    expect(css).toContain(".scans-grid");
+    expect(css).toContain(".scan-card:hover");
+    expect(css).toContain(".scan-row");
+  });
+
+  // These selectors support loading skeletons and visibility/moderation badges.
+  test("has loading and badge selectors been used by scans script", () => {
+    expect(css).toContain("@keyframes shimmer");
+    expect(css).toContain(".skeleton-card");
+    expect(css).toContain(".scan-visibility-badge");
+    expect(css).toContain(".scan-moderation-badge");
+  });
+});

--- a/client/tests/scans.styles.test.js
+++ b/client/tests/scans.styles.test.js
@@ -14,7 +14,7 @@ describe("scans CSS contract", () => {
   });
 
   // These selectors support loading skeletons and visibility/moderation badges.
-  test("has loading and badge selectors been used by scans script", () => {
+  test("has loading and badge selectors used by the scans script", () => {
     expect(css).toContain("@keyframes shimmer");
     expect(css).toContain(".skeleton-card");
     expect(css).toContain(".scan-visibility-badge");

--- a/client/tests/scans.template.test.js
+++ b/client/tests/scans.template.test.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+const path = require("path");
+
+// If key ids/classes disappear, the page JS can break at runtime.
+describe("scans HTML template contract", () => {
+  const templatePath = path.join(__dirname, "../templates/scans.html");
+  const html = fs.readFileSync(templatePath, "utf8");
+
+  // scans.js writes status messages and renders cards into these elements.
+  test("contains scans status and container elements", () => {
+    expect(html).toMatch(/id=\"scans-status\"/);
+    expect(html).toMatch(/id=\"scans-container\"/);
+    expect(html).toMatch(/class=\"scans-grid\"/);
+  });
+
+  // Ensures the scans page actually loads the script that renders data.
+  test("loads scans page script", () => {
+    expect(html).toMatch(/<script src=\"\/static\/js\/scans\.js\"><\/script>/);
+  });
+});
+const fs = require("fs");
+const path = require("path");
+
+// If key ids/classes disappear, the page JS can break at runtime.
+describe("scans HTML template contract", () => {
+  const templatePath = path.join(__dirname, "../templates/scans.html");
+  const html = fs.readFileSync(templatePath, "utf8");
+
+  // scans.js writes status messages and renders cards into these elements.
+  test("contains scans status and container elements", () => {
+    expect(html).toMatch(/id=\"scans-status\"/);
+    expect(html).toMatch(/id=\"scans-container\"/);
+    expect(html).toMatch(/class=\"scans-grid\"/);
+  });
+
+  // Ensures the scans page actually loads the script that renders data.
+  test("loads scans page script", () => {
+    expect(html).toMatch(/<script src=\"\/static\/js\/scans\.js\"><\/script>/);
+  });
+});

--- a/client/tests/scans.template.test.js
+++ b/client/tests/scans.template.test.js
@@ -18,23 +18,3 @@ describe("scans HTML template contract", () => {
     expect(html).toMatch(/<script src=\"\/static\/js\/scans\.js\"><\/script>/);
   });
 });
-const fs = require("fs");
-const path = require("path");
-
-// If key ids/classes disappear, the page JS can break at runtime.
-describe("scans HTML template contract", () => {
-  const templatePath = path.join(__dirname, "../templates/scans.html");
-  const html = fs.readFileSync(templatePath, "utf8");
-
-  // scans.js writes status messages and renders cards into these elements.
-  test("contains scans status and container elements", () => {
-    expect(html).toMatch(/id=\"scans-status\"/);
-    expect(html).toMatch(/id=\"scans-container\"/);
-    expect(html).toMatch(/class=\"scans-grid\"/);
-  });
-
-  // Ensures the scans page actually loads the script that renders data.
-  test("loads scans page script", () => {
-    expect(html).toMatch(/<script src=\"\/static\/js\/scans\.js\"><\/script>/);
-  });
-});


### PR DESCRIPTION
Added unit tests for the client side javascript , html , css. To run paste "npm test -- client/tests/scans.logic.test.js"

<img width="574" height="126" alt="image" src="https://github.com/user-attachments/assets/d3831d46-ccfb-4a7d-bcc3-15027ca561ee" />
