### PR TITLE
Ftr/viewscans/66110/optimize scan details

### DIFF
--- a/client/static/css/viewscan.css
+++ b/client/static/css/viewscan.css
@@ -322,78 +322,17 @@
 }
 
 /* =========================
-   Split Cards (Votes / Verdict+Confidence)
+   Split Cards (Vote)
    Diagonal split design with two sides
    ========================= */
 
 .split-card-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 12px;
   margin-top: 12px;
 }
 
-.split-card {
-  margin-top: 0;
-  border-radius: 14px;
-  overflow: hidden;
-  background: rgba(0, 0, 0, 0.10);
-  display: flex;
-  align-items: stretch;
-  height: 80px;
-  min-width: 0;
-}
-
-.split-card--gold {
-  border: 1px solid #cfb87c
-}
-
-.split-card--green {
-  border: 1px solid rgba(170, 120, 255, 0.55);
-}
-
-.split-card-left {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 12px 14px;
-  background: rgba(0, 0, 0, 0.12);
-  gap: 4px;
-}
-
-.split-card-right {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 12px 14px;
-  background: rgba(0, 0, 0, 0.08);
-  gap: 4px;
-}
-
-.split-divider {
-  width: 2px;
-  height: 100%;
-  background: linear-gradient(
-    135deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.20) 50%,
-    transparent 100%
-  );
-  position: relative;
-}
-
-.split-label {
-  margin: 0;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.60);
-}
 
 .vote-icon {
   display: block;
@@ -410,7 +349,7 @@
 .split-value {
   margin: 0;
   font-size: 20px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.2px;
   color: rgba(255, 255, 255, 0.95);
 }
@@ -419,6 +358,45 @@
   .split-card-row {
     grid-template-columns: 1fr;
   }
+}
+
+.votes-inline-row {
+  display: flex;
+  align-items: stretch;
+  margin-top: 12px;
+  min-width: 0;
+}
+
+.votes-inline-side {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  min-width: 0;
+}
+
+.votes-inline-divider {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.votes-inline-label {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: #CFB87C;
+  text-align: center;
+}
+
+.votes-inline-value {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 /* =========================

--- a/client/static/css/viewscan.css
+++ b/client/static/css/viewscan.css
@@ -54,6 +54,23 @@
    Page header + left description
    ========================= */
 
+body.app .page-header {
+  padding: 6px 0 10px;
+}
+
+body.app .page-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #CFB87C;
+}
+
+body.app .page-underline {
+  margin-top: 0%;
+  background: #222222;
+}
+
 .page-header--with-description {
   margin-bottom: 0px;
 }
@@ -145,26 +162,27 @@
    ========================= */
 
 .scan-quick-meta {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  column-gap: 24px;
-  row-gap: 8px;
-  align-items: start;
-  margin-top: 12px;
-  padding: 6px 16px 12px;
-  border-bottom: 1px solid rgba(207, 184, 124, 0.45);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 14px;
+  min-width: 128px;
+  max-width: 148px;
+  padding: 0;
+  margin: 0;
+  border: 0;
 }
 
 .scan-quick-meta-item {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   min-width: 0;
 }
 
 .scan-quick-meta-label {
   margin: 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.1;
@@ -175,7 +193,7 @@
   display: block;
   margin: 0;
   padding: 0;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   line-height: 1.25;
   color: rgba(255, 255, 255, 0.94);
@@ -184,16 +202,17 @@
 
 @media (max-width: 720px) {
   .scan-quick-meta {
-    column-gap: 16px;
-    row-gap: 6px;
+    gap: 12px;
+    min-width: 110px;
+    max-width: 125px;
   }
 
   .scan-quick-meta-label {
-    font-size: 15px;
+    font-size: 14px;
   }
 
   .scan-quick-meta-value {
-    font-size: 14px;
+    font-size: 12px;
   }
 }
 
@@ -333,6 +352,13 @@
   margin-top: 12px;
 }
 
+.scan-info-votes-row {
+  display: flex;
+  align-items: stretch;
+  gap: 18px;
+  min-width: 0;
+  padding: 8px 0;
+}
 
 .vote-icon {
   display: block;
@@ -358,12 +384,17 @@
   .split-card-row {
     grid-template-columns: 1fr;
   }
+
+  .scan-info-votes-row {
+    gap: 14px;
+  }
 }
 
 .votes-inline-row {
+  flex: 1;
   display: flex;
   align-items: stretch;
-  margin-top: 12px;
+  margin-top: 0;
   min-width: 0;
 }
 
@@ -378,10 +409,6 @@
   min-width: 0;
 }
 
-.votes-inline-divider {
-  width: 1px;
-  background: rgba(255, 255, 255, 0.14);
-}
 
 .votes-inline-label {
   margin: 0;
@@ -543,7 +570,6 @@
 
 .edit-desc-section,
 .make-public-section {
-  margin-top: 16px;
   padding-top: 14px;
   border-top: 1px solid rgba(255, 255, 255, 0.10);
 }

--- a/client/static/css/viewscan.css
+++ b/client/static/css/viewscan.css
@@ -51,6 +51,41 @@
 }
 
 /* =========================
+   Page header + left description
+   ========================= */
+
+.page-header--with-description {
+  margin-bottom: 0px;
+}
+
+.page-header-main {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 0 16px;
+}
+
+.page-header--with-description .page-title {
+  margin: 0;
+  white-space: normal;
+}
+
+.page-header-description {
+  width: 100%;
+  text-align: left;
+}
+
+.page-header-description-text {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.88);
+  word-break: break-word;
+}
+
+/* =========================
    Not-a-card layout (keep same classes/ids)
    ========================= */
 
@@ -108,6 +143,59 @@
 /* =========================
    NEW: Community-style bar cards
    ========================= */
+
+.scan-quick-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 24px;
+  row-gap: 8px;
+  align-items: start;
+  margin-top: 12px;
+  padding: 6px 16px 12px;
+  border-bottom: 1px solid rgba(207, 184, 124, 0.45);
+}
+
+.scan-quick-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.scan-quick-meta-label {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.1;
+  color: #cfb87c;
+}
+
+.scan-quick-meta-value {
+  display: block;
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: rgba(255, 255, 255, 0.94);
+  word-break: break-word;
+}
+
+@media (max-width: 720px) {
+  .scan-quick-meta {
+    column-gap: 16px;
+    row-gap: 6px;
+  }
+
+  .scan-quick-meta-label {
+    font-size: 15px;
+  }
+
+  .scan-quick-meta-value {
+    font-size: 14px;
+  }
+}
 
 .verdict-block {
   margin-top: 12px;
@@ -231,6 +319,106 @@
   z-index: 3;
   white-space: nowrap;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.75);
+}
+
+/* =========================
+   Split Cards (Votes / Verdict+Confidence)
+   Diagonal split design with two sides
+   ========================= */
+
+.split-card-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.split-card {
+  margin-top: 0;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.10);
+  display: flex;
+  align-items: stretch;
+  height: 80px;
+  min-width: 0;
+}
+
+.split-card--gold {
+  border: 1px solid #cfb87c
+}
+
+.split-card--green {
+  border: 1px solid rgba(170, 120, 255, 0.55);
+}
+
+.split-card-left {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 14px;
+  background: rgba(0, 0, 0, 0.12);
+  gap: 4px;
+}
+
+.split-card-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 14px;
+  background: rgba(0, 0, 0, 0.08);
+  gap: 4px;
+}
+
+.split-divider {
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(
+    135deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.20) 50%,
+    transparent 100%
+  );
+  position: relative;
+}
+
+.split-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.60);
+}
+
+.vote-icon {
+  display: block;
+  width: 24px;
+  min-width: 24px;
+  max-width: 24px;
+  height: 24px;
+  max-height: 24px;
+  object-fit: contain;
+  opacity: 0.9;
+  flex: 0 0 auto;
+}
+
+.split-value {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 720px) {
+  .split-card-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* =========================

--- a/client/static/css/viewscan.css
+++ b/client/static/css/viewscan.css
@@ -345,6 +345,16 @@ body.app .page-underline {
    Diagonal split design with two sides
    ========================= */
 
+#votes-card[hidden],
+#private-votes-placeholder[hidden],
+#community-card[hidden],
+#aiclipse-card[hidden],
+#verdict-block[hidden],
+#description-header-section[hidden],
+#private-description-placeholder[hidden] {
+  display: none !important;
+}
+
 .split-card-row {
   display: grid;
   grid-template-columns: 1fr;
@@ -424,6 +434,32 @@ body.app .page-underline {
   align-items: center;
   justify-content: center;
   gap: 8px;
+}
+
+/* =========================
+   Private scan placeholders
+   ========================= */
+
+.private-placeholder {
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.private-placeholder--description {
+  margin-top: 6px;
+  text-align: left;
+}
+
+.private-placeholder--votes {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 84px;
+  padding: 12px 14px;
+  text-align: center;
 }
 
 /* =========================

--- a/client/static/js/viewscan.js
+++ b/client/static/js/viewscan.js
@@ -1226,7 +1226,7 @@ function setupDeletePost(img) {
         sessionStorage.removeItem("selectedScanTitle");
 
         setTimeout(() => {
-          window.location.href = "/scans";
+          window.location.href = "/profile";
         }, 800);
       } catch (err) {
         setStatus(err?.message || "Failed to delete post.", "error");
@@ -1327,7 +1327,7 @@ function setupDeleteScan(img) {
         sessionStorage.removeItem("selectedScanTitle");
 
         setTimeout(() => {
-          window.location.href = "/scans";
+          window.location.href = "/profile";
         }, 800);
       } catch (err) {
         setStatus(err?.message || "Failed to delete scan.", "error");

--- a/client/static/js/viewscan.js
+++ b/client/static/js/viewscan.js
@@ -677,15 +677,33 @@ function renderQuickMeta(img) {
 function renderDescriptionHeader(img) {
   const section = document.getElementById("description-header-section");
   const textEl = document.getElementById("description-text");
+  const privatePlaceholder = document.getElementById("private-description-placeholder");
 
-  if (!section) return;
+  if (!section || !textEl || !privatePlaceholder) return;
 
-  if (img.description) {
+  const isPrivate = isPrivateScan(img);
+  const hasDescription = !!(img && img.description);
+
+  if (hasDescription) {
     section.hidden = false;
+    textEl.hidden = false;
     textEl.textContent = String(img.description);
-  } else {
-    section.hidden = true;
+    privatePlaceholder.hidden = true;
+    return;
   }
+
+  if (isPrivate) {
+    section.hidden = false;
+    textEl.hidden = true;
+    textEl.textContent = "";
+    privatePlaceholder.hidden = false;
+    return;
+  }
+
+  section.hidden = true;
+  textEl.hidden = false;
+  textEl.textContent = "";
+  privatePlaceholder.hidden = true;
 }
 
 // Render verdict and confidence in split card
@@ -713,21 +731,24 @@ function renderVotesCard(img) {
   const card = document.getElementById("votes-card");
   const upvotesEl = document.getElementById("card-upvotes");
   const downvotesEl = document.getElementById("card-downvotes");
+  const privatePlaceholder = document.getElementById("private-votes-placeholder");
 
-  if (!card) return;
+  if (!card || !privatePlaceholder) return;
 
-  // Only show for public posts
   if (isPrivateScan(img)) {
     card.hidden = true;
+    privatePlaceholder.hidden = false;
     return;
   }
 
   const upVotes = img.up_vote_count !== undefined ? img.up_vote_count : 0;
   const downVotes = img.down_vote_count !== undefined ? img.down_vote_count : 0;
 
+  if (upvotesEl) upvotesEl.textContent = String(upVotes);
+  if (downvotesEl) downvotesEl.textContent = String(downVotes);
+
+  privatePlaceholder.hidden = true;
   card.hidden = false;
-  upvotesEl.textContent = String(upVotes);
-  downvotesEl.textContent = String(downVotes);
 }
 
 function renderScan(img, title) {

--- a/client/static/js/viewscan.js
+++ b/client/static/js/viewscan.js
@@ -311,6 +311,25 @@ function normalizeLabelText(raw) {
   return s.replace(/^\s*\d+(\.\d+)?%\s*/i, "").trim();
 }
 
+function getRealLikelihoodPercent(img) {
+  if (!img) return 0;
+
+  const rawLabel = normalizeLabelText(img.label || img.result || img.verdict || "Unknown");
+  const labelLower = rawLabel.toLowerCase();
+  const confidenceRaw = Number.isFinite(img.confidence) ? img.confidence : (img.score ?? 0);
+  const confidence = clamp(confidenceRaw, 0, 1);
+
+  const isAi =
+    labelLower.includes("ai") ||
+    labelLower.includes("fake") ||
+    labelLower.includes("deepfake");
+
+  const isReal = labelLower.includes("real") && !isAi;
+  const realProb = isReal ? confidence : (1 - confidence);
+
+  return clamp(realProb * 100, 0, 100);
+}
+
 function renderAiclipseCard(img) {
   const wrap = document.getElementById("verdict-block");
   const card = document.getElementById("aiclipse-card");
@@ -326,23 +345,8 @@ function renderAiclipseCard(img) {
   }
 
   const rawLabel = normalizeLabelText(img.label || img.result || img.verdict || "Unknown");
-  const labelLower = rawLabel.toLowerCase();
-
-  const confidenceRaw = Number.isFinite(img.confidence) ? img.confidence : (img.score ?? 0);
-  const confidence = clamp(confidenceRaw, 0, 1);
-
-  const isAi =
-    labelLower.includes("ai") ||
-    labelLower.includes("fake") ||
-    labelLower.includes("deepfake");
-
-  const isReal = labelLower.includes("real") && !isAi;
-
-  // INVERTED: Calculate AI (Fake) probability
-  let aiProb = isAi ? confidence : (1 - confidence);
-  aiProb = clamp(aiProb, 0, 1);
-
-  const aiPct = aiProb * 100;
+  const realPct = getRealLikelihoodPercent(img);
+  const aiPct = 100 - realPct;
 
   verdictEl.textContent = rawLabel || "—";
   pctEl.textContent = `${aiPct.toFixed(2)}%`;
@@ -609,36 +613,15 @@ function renderMeta(img) {
     "comment_count",
     "controversial_since",
     "created_at",
+    "updated_at",
     "debug",
     "result",
     "score",
     "user_name",
+    "model_version",
   ]);
 
-  // ---- Show only allowed fields ----
-  addMeta("Visibility", visibilityOf(img));
-  addMeta("Uploaded", formatDate(img.uploaded_at));
-  addMeta("Verdict", img.verdict != null ? String(img.verdict) : "N/A");
-  addMeta("Confidence", toPercent(img.confidence));
-
-  // Always show description field (even if empty/not set yet)
-  const descValue = img.description ? String(img.description) : "(No description yet)";
-  addMeta("Description", descValue);
-
-  // Show vote counts for public posts
-  if (!isPrivateScan(img)) {
-    const upVotes = img.up_vote_count !== undefined ? img.up_vote_count : 0;
-    const downVotes = img.down_vote_count !== undefined ? img.down_vote_count : 0;
-    addMeta("Up Votes", String(upVotes));
-    addMeta("Down Votes", String(downVotes));
-  }
-
-  // Show updated_at if it exists (formatted like uploaded_at)
-  if (img.updated_at) {
-    addMeta("Updated", formatDate(img.updated_at));
-  }
-
-  // Show any other non-hidden fields (but skip description since we showed it above)
+  // Show any other non-hidden fields (but skip those shown in dedicated cards)
   const alreadyShown = new Set([
     "is_public",
     "uploaded_at",
@@ -646,7 +629,6 @@ function renderMeta(img) {
     "verdict",
     "confidence",
     "description",
-    "updated_at",
     "up_vote_count",
     "down_vote_count",
   ]);
@@ -674,6 +656,80 @@ function renderMeta(img) {
     });
 }
 
+function renderQuickMeta(img) {
+  const wrap = document.getElementById("scan-quick-meta");
+  const visibilityEl = document.getElementById("scan-quick-visibility");
+  const uploadedEl = document.getElementById("scan-quick-uploaded");
+
+  if (!wrap || !visibilityEl || !uploadedEl) return;
+
+  if (!img) {
+    wrap.hidden = true;
+    return;
+  }
+
+  visibilityEl.textContent = visibilityOf(img);
+  uploadedEl.textContent = formatDate(img.uploaded_at);
+  wrap.hidden = false;
+}
+
+// Render description header above image
+function renderDescriptionHeader(img) {
+  const section = document.getElementById("description-header-section");
+  const textEl = document.getElementById("description-text");
+
+  if (!section) return;
+
+  if (img.description) {
+    section.hidden = false;
+    textEl.textContent = String(img.description);
+  } else {
+    section.hidden = true;
+  }
+}
+
+// Render verdict and confidence in split card
+function renderVerdictConfidenceCard(img) {
+  const card = document.getElementById("verdict-confidence-card");
+  const verdictEl = document.getElementById("card-verdict");
+  const confidenceEl = document.getElementById("card-confidence");
+
+  if (!card) return;
+
+  const hasVerdict = img.verdict != null;
+  const hasConfidence = img.confidence !== undefined && img.confidence !== null;
+
+  if (hasVerdict || hasConfidence) {
+    card.hidden = false;
+    verdictEl.textContent = hasVerdict ? String(img.verdict) : "—";
+    confidenceEl.textContent = hasConfidence ? `${getRealLikelihoodPercent(img).toFixed(0)}%` : "N/A";
+  } else {
+    card.hidden = true;
+  }
+}
+
+// Render votes in split card (only for public posts)
+function renderVotesCard(img) {
+  const card = document.getElementById("votes-card");
+  const upvotesEl = document.getElementById("card-upvotes");
+  const downvotesEl = document.getElementById("card-downvotes");
+
+  if (!card) return;
+
+  // Only show for public posts
+  if (isPrivateScan(img)) {
+    card.hidden = true;
+    return;
+  }
+
+  const upVotes = img.up_vote_count !== undefined ? img.up_vote_count : 0;
+  const downVotes = img.down_vote_count !== undefined ? img.down_vote_count : 0;
+
+  card.hidden = false;
+  upvotesEl.textContent = String(upVotes);
+  downvotesEl.textContent = String(downVotes);
+}
+
 function renderScan(img, title) {
   currentScan = img;
 
@@ -694,6 +750,10 @@ function renderScan(img, title) {
     if (!ok) return;
 
     renderMeta(currentScan);
+    renderQuickMeta(currentScan);
+    renderDescriptionHeader(currentScan);
+    renderVerdictConfidenceCard(currentScan);
+    renderVotesCard(currentScan);
 
     setupEditDescriptionInline(currentScan);
     setupShowComments(currentScan);
@@ -707,6 +767,9 @@ function renderScan(img, title) {
     if (!ok) return;
 
     renderMeta(currentScan);
+    renderDescriptionHeader(currentScan);
+    renderVerdictConfidenceCard(currentScan);
+    renderVotesCard(currentScan);
 
     setupEditDescriptionInline(currentScan);
     setupShowComments(currentScan);
@@ -720,12 +783,12 @@ function renderScan(img, title) {
 
   if (!img) {
     card.hidden = true;
-    titleEl.textContent = "View Scan";
+    titleEl.textContent = "Post Description";
     setStatus("No scan selected. Go back to Scans and click “View more details”.", "error");
     return;
   }
 
-  titleEl.textContent = title || "View Scan";
+  titleEl.textContent = title || "Post Description";
 
   // Image
   if (img.url) {
@@ -741,8 +804,12 @@ function renderScan(img, title) {
   // NEW: community-style cards
   renderAiclipseCard(img);
   renderCommunityCard(img);
+  renderQuickMeta(img);
 
   renderMeta(img);
+  renderDescriptionHeader(img);
+  renderVerdictConfidenceCard(img);
+  renderVotesCard(img);
   card.hidden = false;
   setStatus("", null);
 

--- a/client/templates/viewscan.html
+++ b/client/templates/viewscan.html
@@ -31,18 +31,6 @@
           <div class="page-underline" role="presentation"></div>
         </section>
 
-          <div id="scan-quick-meta" class="scan-quick-meta" hidden>
-              <div class="scan-quick-meta-item">
-                <span class="scan-quick-meta-label">Visibility</span>
-                <span id="scan-quick-visibility" class="scan-quick-meta-value">—</span>
-              </div>
-
-              <div class="scan-quick-meta-item">
-                <span class="scan-quick-meta-label">Uploaded</span>
-                <span id="scan-quick-uploaded" class="scan-quick-meta-value">—</span>
-              </div>
-            </div>
-
         <!-- <div id="viewscan-status" class="status-message"></div> -->
 
         <section id="viewscan-card" class="viewscan-card" hidden>
@@ -126,8 +114,22 @@
             </section>
 
             <div class="split-card-row">
-              <!-- VOTES CARD -->
-              <section
+              <div class="scan-info-votes-row">
+                <!-- LEFT: stacked meta -->
+                <div id="scan-quick-meta" class="scan-quick-meta scan-quick-meta--inline" hidden>
+                  <div class="scan-quick-meta-item">
+                    <span class="scan-quick-meta-label">Visibility</span>
+                    <span id="scan-quick-visibility" class="scan-quick-meta-value">—</span>
+                  </div>
+
+                  <div class="scan-quick-meta-item">
+                    <span class="scan-quick-meta-label">Uploaded</span>
+                    <span id="scan-quick-uploaded" class="scan-quick-meta-value">—</span>
+                  </div>
+                </div>
+
+                <!-- RIGHT: votes -->
+                <section
                   id="votes-card"
                   class="votes-inline-row"
                   hidden
@@ -158,8 +160,8 @@
                     </div>
                   </div>
                 </section>
+              </div>
             </div>
-          </div>
 
           <div class="viewscan-meta">
             <h2 class="viewscan-heading"></h2>

--- a/client/templates/viewscan.html
+++ b/client/templates/viewscan.html
@@ -126,47 +126,38 @@
             </section>
 
             <div class="split-card-row">
-              <!-- VERDICT & CONFIDENCE CARD -->
-              <section
-                id="verdict-confidence-card"
-                class="split-card split-card--gold"
-                hidden
-              >
-                <div class="split-card-left">
-                  <p class="split-label">Verdict</p>
-                  <p id="card-verdict" class="split-value">—</p>
-                </div>
-                <div class="split-divider"></div>
-                <div class="split-card-right">
-                  <p class="split-label">Real</p>
-                  <p id="card-confidence" class="split-value">0%</p>
-                </div>
-              </section>
-
               <!-- VOTES CARD -->
               <section
-                id="votes-card"
-                class="split-card split-card--green"
-                hidden
-              >
-                <div class="split-card-left">
-                  <img
-                    class="vote-icon"
-                    src="/static/images/upvote.png"
-                    alt="Up votes"
-                  />
-                  <p id="card-upvotes" class="split-value">0</p>
-                </div>
-                <div class="split-divider"></div>
-                <div class="split-card-right">
-                  <img
-                    class="vote-icon"
-                    src="/static/images/downvote.png"
-                    alt="Down votes"
-                  />
-                  <p id="card-downvotes" class="split-value">0</p>
-                </div>
-              </section>
+                  id="votes-card"
+                  class="votes-inline-row"
+                  hidden
+                >
+                  <div class="votes-inline-side">
+                    <p class="votes-inline-label">Real Votes</p>
+                    <div class="votes-inline-value">
+                      <img
+                        class="vote-icon"
+                        src="/static/images/upvote.png"
+                        alt="Up votes"
+                      />
+                      <p id="card-upvotes" class="split-value">0</p>
+                    </div>
+                  </div>
+
+                  <div class="votes-inline-divider"></div>
+
+                  <div class="votes-inline-side">
+                    <p class="votes-inline-label">AI Votes</p>
+                    <div class="votes-inline-value">
+                      <img
+                        class="vote-icon"
+                        src="/static/images/downvote.png"
+                        alt="Down votes"
+                      />
+                      <p id="card-downvotes" class="split-value">0</p>
+                    </div>
+                  </div>
+                </section>
             </div>
           </div>
 

--- a/client/templates/viewscan.html
+++ b/client/templates/viewscan.html
@@ -15,10 +15,33 @@
       {% set page_title = 'View Scan' %} {% include 'partials/topbar.html' %}
 
       <main class="screen">
-        <section class="page-header" aria-label="Page title">
-          <h1 id="viewscan-title" class="page-title">View Scan</h1>
+        <section class="page-header page-header--with-description" aria-label="Page title">
+          <div class="page-header-main">
+            <h1 id="viewscan-title" class="page-title">View Scan</h1>
+
+            <div
+              id="description-header-section"
+              class="page-header-description"
+              hidden
+            >
+              <p id="description-text" class="page-header-description-text"></p>
+            </div>
+          </div>
+
           <div class="page-underline" role="presentation"></div>
         </section>
+
+          <div id="scan-quick-meta" class="scan-quick-meta" hidden>
+              <div class="scan-quick-meta-item">
+                <span class="scan-quick-meta-label">Visibility</span>
+                <span id="scan-quick-visibility" class="scan-quick-meta-value">—</span>
+              </div>
+
+              <div class="scan-quick-meta-item">
+                <span class="scan-quick-meta-label">Uploaded</span>
+                <span id="scan-quick-uploaded" class="scan-quick-meta-value">—</span>
+              </div>
+            </div>
 
         <!-- <div id="viewscan-status" class="status-message"></div> -->
 
@@ -101,10 +124,54 @@
                 </div>
               </div>
             </section>
+
+            <div class="split-card-row">
+              <!-- VERDICT & CONFIDENCE CARD -->
+              <section
+                id="verdict-confidence-card"
+                class="split-card split-card--gold"
+                hidden
+              >
+                <div class="split-card-left">
+                  <p class="split-label">Verdict</p>
+                  <p id="card-verdict" class="split-value">—</p>
+                </div>
+                <div class="split-divider"></div>
+                <div class="split-card-right">
+                  <p class="split-label">Real</p>
+                  <p id="card-confidence" class="split-value">0%</p>
+                </div>
+              </section>
+
+              <!-- VOTES CARD -->
+              <section
+                id="votes-card"
+                class="split-card split-card--green"
+                hidden
+              >
+                <div class="split-card-left">
+                  <img
+                    class="vote-icon"
+                    src="/static/images/upvote.png"
+                    alt="Up votes"
+                  />
+                  <p id="card-upvotes" class="split-value">0</p>
+                </div>
+                <div class="split-divider"></div>
+                <div class="split-card-right">
+                  <img
+                    class="vote-icon"
+                    src="/static/images/downvote.png"
+                    alt="Down votes"
+                  />
+                  <p id="card-downvotes" class="split-value">0</p>
+                </div>
+              </section>
+            </div>
           </div>
 
           <div class="viewscan-meta">
-            <h2 class="viewscan-heading">Details</h2>
+            <h2 class="viewscan-heading"></h2>
 
             <!-- Populated from JS -->
             <dl class="meta-list" id="meta-list"></dl>

--- a/client/templates/viewscan.html
+++ b/client/templates/viewscan.html
@@ -26,6 +26,13 @@
             >
               <p id="description-text" class="page-header-description-text"></p>
             </div>
+            <div
+              id="private-description-placeholder"
+              class="private-placeholder private-placeholder--description"
+              hidden
+            >
+              You will need to publish post to add a description.
+            </div>
           </div>
 
           <div class="page-underline" role="presentation"></div>
@@ -160,6 +167,13 @@
                     </div>
                   </div>
                 </section>
+                <div
+                  id="private-votes-placeholder"
+                  class="private-placeholder private-placeholder--votes"
+                  hidden
+                >
+                  Publish post to view community votes
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
Public Scan:
<img width="476" height="940" alt="image" src="https://github.com/user-attachments/assets/b913b75c-7101-4994-bd3f-eff1e74b7d6a" />

Private Scan:
<img width="478" height="942" alt="image" src="https://github.com/user-attachments/assets/8f5738cb-905b-46f6-8323-f1d8920bb369" />

Hi lads, I've done up the scanned details in our view scan page. Changes I've made is what follows:
- I made it so that the information can be viewed without needing to scroll down.
- Jamie removed unnecessary details that are "noise" for users.
- Private scans hide votes and post descriptions with a placeholder.

To test:
- Check the public scan if details are displayed correctly.
- Check if a placeholder (post desc & community votes) is present if a scan is private.

Note: 
- I've tried doing up the topbar's "View Scan" for the post description. I did it, but it just didn't look practical since a user may type up a long description. We still need to show the user what they have put as a description as a whole. Therefore, I just removed it completely.
- I know the bar is displaying "Likely AI" instead of the word "Fake." I will still need to talk to Noah about this, but it will be a separate task.