### PR TITLE
Increase max image size to 20 MB and remove WebP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,5 @@ model-cycle/Folder.DotSettings.user
 .claude*
 
 
+.mcp.json
+CLAUDE.md

--- a/client/static/js/upload.js
+++ b/client/static/js/upload.js
@@ -71,8 +71,8 @@ async function jsonFetch(method, url, body) {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
-  const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
-  const TOO_LARGE_MSG = "Image is too large. Max allowed size is 5 MB.";
+  const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+  const TOO_LARGE_MSG = "Image is too large. Max allowed size is 20 MB.";
 
   const fileInput = document.getElementById("file-input");
   const fileLabel = document.querySelector("label.file-upload");
@@ -490,7 +490,7 @@ window.addEventListener("DOMContentLoaded", () => {
         return;
       }
     } else if (isData) {
-      const dataUrlRegex = /^data:image\/(png|jpeg|jpg|webp);base64,[A-Za-z0-9+/=]+$/i;
+      const dataUrlRegex = /^data:image\/(png|jpeg|jpg);base64,[A-Za-z0-9+/=]+$/i;
       if (!dataUrlRegex.test(url)) {
         imgEl.removeAttribute("src");
         return;

--- a/client/templates/docs.html
+++ b/client/templates/docs.html
@@ -462,7 +462,7 @@
                 <h3>Limits</h3>
                 <ul class="muted" style="margin-top: 8px">
                   <li>Formats: JPEG, PNG</li>
-                  <li>Max file size: 5 MB</li>
+                  <li>Max file size: 20 MB</li>
                   <li>Max dimensions: 12000×12000</li>
                   <li>Max pixels: 40 MP</li>
                 </ul>

--- a/client/templates/login.html
+++ b/client/templates/login.html
@@ -162,7 +162,7 @@
             <h2>Detect</h2>
 
             <label for="file-input">Image file (JPEG/PNG)</label>
-            <input id="file-input" type="file" accept="image/*" />
+            <input id="file-input" type="file" accept="image/png, image/jpeg" />
 
             <div class="row">
               <button id="btn-check" disabled>Analyze image</button>

--- a/client/templates/upload.html
+++ b/client/templates/upload.html
@@ -63,7 +63,7 @@
         </div>
 
         <div class="upload-actions">
-          <input id="file-input" type="file" accept="image/*" hidden />
+          <input id="file-input" type="file" accept="image/png, image/jpeg" hidden />
 
           <label for="file-input" class="file-upload"> Choose Image </label>
 

--- a/gateway/app/core/settings.py
+++ b/gateway/app/core/settings.py
@@ -48,7 +48,7 @@ class Settings:
             detection_token_secret=os.getenv("DETECTION_TOKEN_SECRET"),
             internal_auth_token=os.getenv("INTERNAL_AUTH_TOKEN"),
             model_cycle_uri = os.getenv("MOEDEL_CYCLE_URI"),
-            max_file_size=5 * 1024 * 1024,
+            max_file_size=20 * 1024 * 1024,
             max_width=12000,
             max_height=12000,
             max_pixels=40_000_000,

--- a/media/main-media.py
+++ b/media/main-media.py
@@ -50,7 +50,7 @@ S3_BUCKET = "images"
 MODEL_CYCLE_URL = os.getenv("MODEL_CYCLE_URL", "http://model-cycle:3000")
 
 ALLOWED_TYPES = {"image/jpeg", "image/jpg", "image/png"}
-MAX_FILE_SIZE = 5 * 1024 * 1024
+MAX_FILE_SIZE = 20 * 1024 * 1024
 
 # Presign TTLs (seconds)
 PRESIGN_PRIVATE_EXPIRES_S = 300

--- a/model-cycle/ModelCycle/Services/Data/DatasetService.cs
+++ b/model-cycle/ModelCycle/Services/Data/DatasetService.cs
@@ -17,8 +17,8 @@ public class DatasetService : IDatasetService
     
     public string GetLocalFilePath(string mediaId)
     {
-        var supportedExtensions = new[] { ".jpg", ".jpeg", ".png", ".webp" };
-        
+        var supportedExtensions = new[] { ".jpg", ".jpeg", ".png" };
+
         foreach (var ext in supportedExtensions)
         {
             var path = Path.Combine(_storagePath, $"{mediaId}{ext}");
@@ -46,7 +46,7 @@ public class DatasetService : IDatasetService
     
     public Task DeleteImageAsync(string mediaId)
     {
-        var supportedExtensions = new[] { ".jpg", ".jpeg", ".png", ".webp" };
+        var supportedExtensions = new[] { ".jpg", ".jpeg", ".png" };
         foreach (var ext in supportedExtensions)
         {
             var filePath = Path.Combine(_storagePath, $"{mediaId}{ext}");


### PR DESCRIPTION
- Raised the maximum allowed image upload size from 5 MB to 20 MB across client, gateway, and media services 
- Removed .webp from supported formats to ensure consistent format enforcement (PNG/JPEG only) across all services
- Narrowed accept attributes on file inputs from image/* to image/png, image/jpeg