### PR TITLE
Added the ability to zoom on an image in community and my scans page

### DIFF
--- a/client/static/css/core/image-zoom.css
+++ b/client/static/css/core/image-zoom.css
@@ -1,0 +1,75 @@
+/* =========================
+   IMAGE ZOOM MODAL (shared)
+   ========================= */
+
+.imgzoom-backdrop {
+  display: none; /* shown via JS inline style when open */
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.92);
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.imgzoom-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 10000;
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.imgzoom-close:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.imgzoom-container {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+  cursor: zoom-in;
+}
+
+.imgzoom-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  pointer-events: none;
+  transform-origin: center center;
+  will-change: transform;
+  display: block;
+}
+
+.imgzoom-hint {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 0.2s;
+  margin: 0;
+}

--- a/client/static/js/core/image-zoom.js
+++ b/client/static/js/core/image-zoom.js
@@ -1,0 +1,239 @@
+/**
+ * Supports:
+ *   - Mouse wheel zoom toward cursor
+ *   - Drag to pan when zoomed
+ *   - Double-click to toggle 2.5× zoom
+ *   - Pinch-to-zoom on touch devices
+ *   - Single-finger drag when zoomed on touch
+ *   - ESC / close button / backdrop click to dismiss
+ */
+(function () {
+  "use strict";
+
+  var MIN_SCALE = 1;
+  var MAX_SCALE = 4;
+
+  var overlay = null;
+  var zoomImg = null;
+  var hintEl = null;
+  var containerEl = null;
+
+  var scale = 1;
+  var tx = 0;
+  var ty = 0;
+  var isDragging = false;
+  var lastPos = { x: 0, y: 0 };
+  var pinchDist0 = null;
+
+  function clamp(v, a, b) {
+    return v < a ? a : v > b ? b : v;
+  }
+
+  function applyTransform() {
+    zoomImg.style.transform =
+      "translate(" + tx + "px, " + ty + "px) scale(" + scale + ")";
+    containerEl.style.cursor =
+      scale > 1 ? (isDragging ? "grabbing" : "grab") : "zoom-in";
+    hintEl.style.opacity = scale > 1 ? "1" : "0";
+  }
+
+  function getContainerCenter() {
+    var r = containerEl.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  }
+
+  function clampedTranslate(newTx, newTy, s) {
+    var maxX = (containerEl.clientWidth * (s - 1)) / 2;
+    var maxY = (containerEl.clientHeight * (s - 1)) / 2;
+    return {
+      x: clamp(newTx, -maxX, maxX),
+      y: clamp(newTy, -maxY, maxY),
+    };
+  }
+
+  function zoomToward(pivotX, pivotY, ratio) {
+    var c = getContainerCenter();
+    var px = pivotX - c.x;
+    var py = pivotY - c.y;
+    var newS = clamp(scale * ratio, MIN_SCALE, MAX_SCALE);
+    if (newS <= MIN_SCALE) {
+      scale = MIN_SCALE;
+      tx = 0;
+      ty = 0;
+    } else {
+      var newTx = px - ((px - tx) / scale) * newS;
+      var newTy = py - ((py - ty) / scale) * newS;
+      var ct = clampedTranslate(newTx, newTy, newS);
+      scale = newS;
+      tx = ct.x;
+      ty = ct.y;
+    }
+    applyTransform();
+  }
+
+  function openModal(src) {
+    scale = 1;
+    tx = 0;
+    ty = 0;
+    zoomImg.src = src;
+    applyTransform();
+    overlay.style.display = "flex";
+    overlay.style.alignItems = "center";
+    overlay.style.justifyContent = "center";
+    document.body.style.overflow = "hidden";
+  }
+
+  function closeModal() {
+    overlay.style.display = "none";
+    document.body.style.overflow = "";
+    scale = 1;
+    tx = 0;
+    ty = 0;
+  }
+
+  function onWheel(e) {
+    e.preventDefault();
+    zoomToward(e.clientX, e.clientY, e.deltaY > 0 ? 0.85 : 1.15);
+  }
+
+  function onMouseDown(e) {
+    if (scale <= 1) return;
+    isDragging = true;
+    lastPos = { x: e.clientX, y: e.clientY };
+    containerEl.style.cursor = "grabbing";
+    e.preventDefault();
+  }
+
+  function onMouseMove(e) {
+    if (!isDragging) return;
+    var dx = e.clientX - lastPos.x;
+    var dy = e.clientY - lastPos.y;
+    lastPos = { x: e.clientX, y: e.clientY };
+    var ct = clampedTranslate(tx + dx, ty + dy, scale);
+    tx = ct.x;
+    ty = ct.y;
+    applyTransform();
+  }
+
+  function onMouseUp() {
+    isDragging = false;
+    containerEl.style.cursor = scale > 1 ? "grab" : "zoom-in";
+  }
+
+  function onDoubleClick(e) {
+    if (scale > 1) {
+      scale = 1;
+      tx = 0;
+      ty = 0;
+      applyTransform();
+    } else {
+      zoomToward(e.clientX, e.clientY, 2.5);
+    }
+  }
+
+  function onTouchStart(e) {
+    if (e.touches.length === 2) {
+      pinchDist0 = Math.hypot(
+        e.touches[0].clientX - e.touches[1].clientX,
+        e.touches[0].clientY - e.touches[1].clientY
+      );
+      isDragging = false;
+    } else if (e.touches.length === 1 && scale > 1) {
+      isDragging = true;
+      lastPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+  }
+
+  function onTouchMove(e) {
+    e.preventDefault();
+    if (e.touches.length === 2 && pinchDist0 !== null) {
+      var dist = Math.hypot(
+        e.touches[0].clientX - e.touches[1].clientX,
+        e.touches[0].clientY - e.touches[1].clientY
+      );
+      var midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+      var midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+      zoomToward(midX, midY, dist / pinchDist0);
+      pinchDist0 = dist;
+    } else if (e.touches.length === 1 && isDragging) {
+      var dx = e.touches[0].clientX - lastPos.x;
+      var dy = e.touches[0].clientY - lastPos.y;
+      lastPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      var ct = clampedTranslate(tx + dx, ty + dy, scale);
+      tx = ct.x;
+      ty = ct.y;
+      applyTransform();
+    }
+  }
+
+  function onTouchEnd(e) {
+    if (e.touches.length < 2) pinchDist0 = null;
+    if (e.touches.length === 0) isDragging = false;
+  }
+
+  function buildOverlay() {
+    var el = document.createElement("div");
+    el.className = "imgzoom-backdrop";
+    el.style.display = "none";
+    el.innerHTML =
+      '<button class="imgzoom-close" aria-label="Close zoom">' +
+      '<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">' +
+      '<line x1="18" y1="6" x2="6" y2="18"/>' +
+      '<line x1="6" y1="6" x2="18" y2="18"/>' +
+      "</svg></button>" +
+      '<div class="imgzoom-container">' +
+      '<img class="imgzoom-img" alt="" draggable="false" />' +
+      "</div>" +
+      '<p class="imgzoom-hint" style="opacity:0">Double-tap / click to reset</p>';
+
+    overlay = el;
+    containerEl = el.querySelector(".imgzoom-container");
+    zoomImg = el.querySelector(".imgzoom-img");
+    hintEl = el.querySelector(".imgzoom-hint");
+
+    // Backdrop click closes
+    el.addEventListener("click", function (e) {
+      if (e.target === el) closeModal();
+    });
+
+    // Close button
+    el.querySelector(".imgzoom-close").addEventListener("click", closeModal);
+
+    // ESC key
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && overlay.style.display !== "none") closeModal();
+    });
+
+    // Mouse events
+    containerEl.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    containerEl.addEventListener("dblclick", onDoubleClick);
+
+    // Wheel (non-passive)
+    containerEl.addEventListener("wheel", onWheel, { passive: false });
+
+    // Touch events
+    containerEl.addEventListener("touchstart", onTouchStart, { passive: true });
+    containerEl.addEventListener("touchmove", onTouchMove, { passive: false });
+    containerEl.addEventListener("touchend", onTouchEnd, { passive: true });
+
+    document.body.appendChild(el);
+  }
+
+  /**
+   * Attach zoom behaviour to an <img> element.
+   * Safe to call multiple times on the same element (idempotent).
+   */
+  function attachImageZoom(srcImg) {
+    if (!overlay) buildOverlay();
+    if (srcImg._zoomAttached) return;
+    srcImg._zoomAttached = true;
+    srcImg.style.cursor = "zoom-in";
+    srcImg.addEventListener("click", function () {
+      if (srcImg.src) openModal(srcImg.src);
+    });
+  }
+
+  window.attachImageZoom = attachImageZoom;
+})();

--- a/client/static/js/flows/detection/results-page.js
+++ b/client/static/js/flows/detection/results-page.js
@@ -451,6 +451,9 @@
         }
       };
       img.src = pending.previewUrl;
+      if (typeof window.attachImageZoom === "function") {
+        window.attachImageZoom(img);
+      }
 
       if (pending.source === "indexeddb" && pending.previewUrl.startsWith("blob:")) {
         global.addEventListener(

--- a/client/static/js/pages/library/viewscan/index.js
+++ b/client/static/js/pages/library/viewscan/index.js
@@ -315,6 +315,9 @@
       imageEl.src = img.url;
       imageEl.alt = title || "Selected scan image";
       imageEl.hidden = false;
+      if (typeof window.attachImageZoom === "function") {
+        window.attachImageZoom(imageEl);
+      }
     } else {
       imageEl.removeAttribute("src");
       imageEl.alt = "No image available.";

--- a/client/templates/pages/detection/results.html
+++ b/client/templates/pages/detection/results.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="{{ asset_url('css/pages/detection/results.css') }}" />
   <link rel="stylesheet" href="{{ asset_url('css/core/loader.css') }}" />
   <link rel="stylesheet" href="{{ asset_url('css/pages/detection/flow-header.css') }}" />
+  <link rel="stylesheet" href="{{ asset_url('css/core/image-zoom.css') }}" />
 </head>
 
 <body class="app">
@@ -134,6 +135,7 @@
   </div>
 
   <script src="{{ asset_url('js/core/navigation.js') }}"></script>
+  <script src="{{ asset_url('js/core/image-zoom.js') }}"></script>
   <script src="{{ asset_url('js/core/app.js') }}"></script>
   <script src="{{ asset_url('js/core/http.js') }}"></script>
   <script src="{{ asset_url('js/core/status.js') }}"></script>

--- a/client/templates/pages/library/viewscan.html
+++ b/client/templates/pages/library/viewscan.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="{{ asset_url('css/core/community-ui.css') }}" />
   <link rel="stylesheet" href="{{ asset_url('css/pages/library/viewscan/page.css') }}" />
   <link rel="stylesheet" href="{{ asset_url('css/core/loader.css') }}" />
+  <link rel="stylesheet" href="{{ asset_url('css/core/image-zoom.css') }}" />
 </head>
 
 <body class="app">
@@ -132,6 +133,7 @@
   </div>
   {% include 'partials/navigation/navbar.html' %}
 
+  <script src="{{ asset_url('js/core/image-zoom.js') }}"></script>
   <script src="{{ asset_url('js/core/http.js') }}"></script>
   <script src="{{ asset_url('js/pages/library/api.js') }}"></script>
   <script src="{{ asset_url('js/core/navigation.js') }}"></script>

--- a/community/app/components/post/ImageZoomModal.jsx
+++ b/community/app/components/post/ImageZoomModal.jsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 4;
+
+function clamp(v, a, b) {
+  return v < a ? a : v > b ? b : v;
+}
+
+export default function ImageZoomModal({ src, alt, onClose }) {
+  const containerRef = useRef(null);
+  const imgRef = useRef(null);
+  const hintRef = useRef(null);
+
+  const scale = useRef(1);
+  const tx = useRef(0);
+  const ty = useRef(0);
+  const isDragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+  const pinchDist0 = useRef(null);
+
+  // Lock body scroll while open
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  // Close on ESC
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function applyTransform() {
+    if (imgRef.current) {
+      imgRef.current.style.transform = `translate(${tx.current}px, ${ty.current}px) scale(${scale.current})`;
+    }
+    if (containerRef.current) {
+      containerRef.current.style.cursor =
+        scale.current > 1 ? (isDragging.current ? "grabbing" : "grab") : "zoom-in";
+    }
+    if (hintRef.current) {
+      hintRef.current.style.opacity = scale.current > 1 ? "1" : "0";
+    }
+  }
+
+  function getContainerCenter() {
+    const el = containerRef.current;
+    if (!el) return { x: 0, y: 0 };
+    const r = el.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  }
+
+  function clampedTranslate(newTx, newTy, s) {
+    const el = containerRef.current;
+    if (!el) return { x: newTx, y: newTy };
+    const maxX = (el.clientWidth * (s - 1)) / 2;
+    const maxY = (el.clientHeight * (s - 1)) / 2;
+    return { x: clamp(newTx, -maxX, maxX), y: clamp(newTy, -maxY, maxY) };
+  }
+
+  function zoomToward(pivotX, pivotY, ratio) {
+    const c = getContainerCenter();
+    const px = pivotX - c.x;
+    const py = pivotY - c.y;
+    const newS = clamp(scale.current * ratio, MIN_SCALE, MAX_SCALE);
+    if (newS <= MIN_SCALE) {
+      scale.current = MIN_SCALE;
+      tx.current = 0;
+      ty.current = 0;
+    } else {
+      const newTx = px - ((px - tx.current) / scale.current) * newS;
+      const newTy = py - ((py - ty.current) / scale.current) * newS;
+      const ct = clampedTranslate(newTx, newTy, newS);
+      scale.current = newS;
+      tx.current = ct.x;
+      ty.current = ct.y;
+    }
+    applyTransform();
+  }
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    function onWheel(e) {
+      e.preventDefault();
+      zoomToward(e.clientX, e.clientY, e.deltaY > 0 ? 0.85 : 1.15);
+    }
+
+    function onTouchMove(e) {
+      e.preventDefault();
+      if (e.touches.length === 2 && pinchDist0.current !== null) {
+        const dist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY
+        );
+        const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+        zoomToward(midX, midY, dist / pinchDist0.current);
+        pinchDist0.current = dist;
+      } else if (e.touches.length === 1 && isDragging.current) {
+        const dx = e.touches[0].clientX - lastPos.current.x;
+        const dy = e.touches[0].clientY - lastPos.current.y;
+        lastPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        const ct = clampedTranslate(tx.current + dx, ty.current + dy, scale.current);
+        tx.current = ct.x;
+        ty.current = ct.y;
+        applyTransform();
+      }
+    }
+
+    container.addEventListener("wheel", onWheel, { passive: false });
+    container.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => {
+      container.removeEventListener("wheel", onWheel);
+      container.removeEventListener("touchmove", onTouchMove);
+    };
+  }, []); 
+
+  function onMouseDown(e) {
+    if (scale.current <= 1) return;
+    isDragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    if (containerRef.current) containerRef.current.style.cursor = "grabbing";
+    e.preventDefault();
+  }
+
+  function onMouseMove(e) {
+    if (!isDragging.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    const ct = clampedTranslate(tx.current + dx, ty.current + dy, scale.current);
+    tx.current = ct.x;
+    ty.current = ct.y;
+    applyTransform();
+  }
+
+  function onMouseUp() {
+    isDragging.current = false;
+    if (containerRef.current) {
+      containerRef.current.style.cursor = scale.current > 1 ? "grab" : "zoom-in";
+    }
+  }
+
+  function onDoubleClick(e) {
+    if (scale.current > 1) {
+      scale.current = 1;
+      tx.current = 0;
+      ty.current = 0;
+      applyTransform();
+    } else {
+      zoomToward(e.clientX, e.clientY, 2.5);
+    }
+  }
+
+  function onTouchStart(e) {
+    if (e.touches.length === 2) {
+      pinchDist0.current = Math.hypot(
+        e.touches[0].clientX - e.touches[1].clientX,
+        e.touches[0].clientY - e.touches[1].clientY
+      );
+      isDragging.current = false;
+    } else if (e.touches.length === 1 && scale.current > 1) {
+      isDragging.current = true;
+      lastPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+  }
+
+  function onTouchEnd(e) {
+    if (e.touches.length < 2) pinchDist0.current = null;
+    if (e.touches.length === 0) isDragging.current = false;
+  }
+
+  const modal = (
+    <div
+      className="imgzoom-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <button className="imgzoom-close" onClick={onClose} aria-label="Close zoom">
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      <div
+        ref={containerRef}
+        className="imgzoom-container"
+        style={{ cursor: "zoom-in" }}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseUp}
+        onDoubleClick={onDoubleClick}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
+        <img
+          ref={imgRef}
+          src={src}
+          alt={alt}
+          className="imgzoom-img"
+          draggable={false}
+        />
+      </div>
+
+      <p ref={hintRef} className="imgzoom-hint" style={{ opacity: 0 }}>
+        Double-tap / click to reset
+      </p>
+    </div>
+  );
+
+  return typeof document !== "undefined"
+    ? createPortal(modal, document.body)
+    : null;
+}

--- a/community/app/components/post/PostMedia.jsx
+++ b/community/app/components/post/PostMedia.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import ImageZoomModal from "./ImageZoomModal";
 
 export default function PostMedia({
   url,
@@ -8,14 +10,27 @@ export default function PostMedia({
   isUserCorrect,
   groundTruth,
 }) {
+  const [zoomOpen, setZoomOpen] = useState(false);
+
   return (
     <div className="comm_postImageWrap">
       <img
         className="comm_postImage"
         src={url}
         alt={label || "Community image"}
-        onClick={onClick}
+        onClick={() => {
+          onClick?.();
+          setZoomOpen(true);
+        }}
       />
+
+      {zoomOpen && (
+        <ImageZoomModal
+          src={url}
+          alt={label || "Community image"}
+          onClose={() => setZoomOpen(false)}
+        />
+      )}
 
       {/* Full overlay */}
       <AnimatePresence>

--- a/community/app/layout.jsx
+++ b/community/app/layout.jsx
@@ -1,6 +1,7 @@
 import "./styles/appShell.css";
 import "./global.css";
 import "./styles/modal/modal.css";
+import "./styles/imageZoom.css";
 
 import ShellWrapper from "./components/ShellWrapper";
 import { headers } from "next/headers";

--- a/community/app/styles/imageZoom.css
+++ b/community/app/styles/imageZoom.css
@@ -1,0 +1,75 @@
+/* =========================
+   IMAGE ZOOM MODAL
+   ========================= */
+
+.imgzoom-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.imgzoom-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 10000;
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.imgzoom-close:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.imgzoom-container {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.imgzoom-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  pointer-events: none;
+  transform-origin: center center;
+  will-change: transform;
+  display: block;
+}
+
+.imgzoom-hint {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 0.2s;
+}

--- a/community/app/styles/postBox.css
+++ b/community/app/styles/postBox.css
@@ -271,7 +271,7 @@
   aspect-ratio: 1;
   -o-object-fit: cover;
   object-fit: cover;
-  cursor: pointer;
+  cursor: zoom-in;
   background: rgba(255, 255, 255, .05);
   width: 100%;
   height: auto;


### PR DESCRIPTION
When a user now visits the community, they can zoom in on the image. They can double-click to zoom further or use the scroll wheel to zoom in. 

To test:
Click on a post in the community, and it should go full screen, then you can use the scroll whele ot double click to zoom more
Same for my uploads page

<img width="974" height="974" alt="image" src="https://github.com/user-attachments/assets/da5d4517-9c5b-451e-9718-458dd28a6b1c" />


